### PR TITLE
feat(section-0,engine,bot): single-message tutorial flow (name → starter → talent) + global-only slash sync

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,64 +1,115 @@
-import discord
+import discord, os, asyncio
+import asyncpg
 from discord.ext import commands
-import os
-
 from core import config
+from core.repository import MemoryRepository, SqlRepository
+from core.validator import validate_all
+from core.narrative import Narrative
+from data.section_0.story import STORY as STORY_SECTION_0
 
-intents = discord.Intents.default()
-bot = commands.Bot(command_prefix="!", intents=intents)
-
-
-async def sync_commands():
-    """Syncs slash commands to specific guilds or globally."""
-    print("--- Syncing Commands ---")
-
-    # Use the GUILD_IDS list directly from your config
-    if config.GUILD_IDS:
-        for guild_id in config.GUILD_IDS:
-            try:
-                guild = discord.Object(id=guild_id)
-                await bot.tree.sync(guild=guild)
-                print(f"  > Synced commands to guild {guild_id}")
-            except Exception as e:
-                print(f"  > Failed to sync to guild {guild_id}: {e}")
-    else:
-        # Sync globally if no guild IDs are provided
+async def force_clear_all_guild_commands(bot: commands.Bot):
+    """
+    Remove ANY previously-synced guild-scoped commands in every guild the bot is in.
+    Run this AFTER the bot is ready (guild cache is populated).
+    """
+    print("— Force-clearing ALL guild-scoped commands (post-ready) —")
+    cleared_any = False
+    for guild in bot.guilds:
         try:
-            await bot.tree.sync()
-            print("  > Globally synced commands")
+            bot.tree.clear_commands(guild=guild)           # wipe per-guild commands
+            await bot.tree.sync(guild=guild)                # push the wipe
+            print(f"  > Cleared guild commands for {guild.id} ({guild.name})")
+            cleared_any = True
         except Exception as e:
-            print(f"  > An error with global syncing occurred: {e}")
+            print(f"  > Failed to clear guild {guild.id}: {e}")
+    if not cleared_any:
+        print("  > No guilds to clear (cache empty or not in any guild)")
 
+async def build_repo():
+    has_db = all([config.DB_HOST, config.DB_PORT, config.DB_USER, config.DB_PASSWORD, config.DB_NAME])
+    if not has_db:
+        return MemoryRepository()
+
+    pool = await asyncpg.create_pool(
+        host=config.DB_HOST,
+        port=int(config.DB_PORT or 5432),
+        user=config.DB_USER,
+        password=config.DB_PASSWORD,
+        database=config.DB_NAME,
+        min_size=1,
+        max_size=5,
+        command_timeout=30,
+    )
+    return SqlRepository(pool)
+
+async def sync_commands_global(bot: commands.Bot):
+    print("--- Syncing Commands (GLOBAL) ---")
+    try:
+        await bot.tree.sync()
+        print("  > Globally synced commands")
+    except Exception as e:
+        print(f"  > An error with global syncing occurred: {e}")
     print("----------------------")
 
+class GuildBot(commands.Bot):
+    async def setup_hook(self):
+        # 1) validate content first
+        validate_all()
 
-@bot.event
-async def on_ready():
-    """This event fires when the bot is connected and ready."""
-    print(f'✅ Logged in as {bot.user.name}')
-    print('------')
+        # 2) Load DB cog FIRST so it creates the Postgres pool / runs migrations
+        try:
+            await self.load_extension('cogs.database')
+            print('  > Loaded cog: database.py (migrations will run here)')
+        except Exception as e:
+            print(f'  > Failed to load database cog: {e}')
 
-    print("--- Loading Cogs ---")
-    # Load the database cog first as other cogs might depend on it.
-    try:
-        await bot.load_extension('cogs.database')
-        print('  > Loaded cog: database.py')
-    except Exception as e:
-        print(f'  > Failed to load cog database.py: {e}')
+        # 3) Use the pool from the Database cog for the Repository
+        db_cog = self.get_cog("Database")
+        pool = getattr(db_cog, "pool", None)
+        if pool:
+            self.repo = SqlRepository(pool)
+            print("  > Repository: SqlRepository (asyncpg pool from Database cog)")
+        else:
+            self.repo = MemoryRepository()
+            print("  > Repository: MemoryRepository (no DB pool found)")
 
+        # 4) Narratives
+        self.narratives = {"section_0": Narrative(STORY_SECTION_0, self.repo)}
 
-    for filename in os.listdir('./cogs'):
-        # Make sure not to load database again
-        if filename.endswith('.py') and filename != 'database.py':
+        # 5) Load the rest of the cogs (skip __init__.py and database.py)
+        for filename in os.listdir('./cogs'):
+            if not filename.endswith('.py'):
+                continue
+            if filename in ('__init__.py', 'database.py'):
+                continue
+            modname = filename[:-3]
             try:
-                await bot.load_extension(f'cogs.{filename[:     -3]}')
+                await self.load_extension(f'cogs.{modname}')
                 print(f'  > Loaded cog: {filename}')
             except Exception as e:
                 print(f'  > Failed to load cog {filename}: {e}')
-    print("--------------------")
 
-    # Now, sync the commands after they have all been loaded
-    await sync_commands()
+        print("✅ Startup complete — ready for commands.")
 
+# intents & bot
+intents = discord.Intents.default()
+bot = GuildBot(command_prefix=commands.when_mentioned, intents=intents)
+
+@bot.event
+async def on_ready():
+    # Run the cleanup ONCE after the bot is fully ready (guilds are cached)
+    if getattr(bot, "_did_global_cleanup", False):
+        return
+    bot._did_global_cleanup = True
+
+    # 1) Wipe all per-guild commands everywhere
+    await force_clear_all_guild_commands(bot)
+
+    # 2) Register ONLY the global set
+    await sync_commands_global(bot)
+
+    print("🧹 Guild-scoped commands cleared. Global commands are now the single source.")
 
 bot.run(config.DISCORD_TOKEN)
+
+

--- a/cogs/game.py
+++ b/cogs/game.py
@@ -13,380 +13,227 @@ from data.pets import PET_DATABASE
 from utils.helpers import get_pet_image_url, get_status_bar
 from data.abilities import STARTER_TALENTS
 
+
+
 # A helper list to get only the starter pets from the database
 STARTER_PETS_LIST = [pet for pet in PET_DATABASE.values() if pet.get('rarity') == 'Starter']
 
 
-# --- StartModal Class ---
-# The logic inside this class is already good. No changes needed.
-# A modal to collect the user's desired username.
-class StartModal(discord.ui.Modal, title="Guild Registration"):
-    def __init__(self, bot):
-        super().__init__()
-        self.bot = bot
-        self.username_input = discord.ui.TextInput(
-            label="Choose an in-game username",
-            placeholder="Enter your username (max 20 characters)...",
-            max_length=20,
-            required=True
+class NameModal(discord.ui.Modal):
+    def __init__(self, title: str, label: str, min_len: int, max_len: int, on_submit):
+        super().__init__(title=title, timeout=120)
+        self.on_submit_callback = on_submit
+        self.input = discord.ui.TextInput(
+            label=label, placeholder="Enter your name",
+            min_length=min_len, max_length=max_len, required=True
         )
-        self.add_item(self.username_input)
+        self.add_item(self.input)
 
     async def on_submit(self, interaction: discord.Interaction):
-        await interaction.response.defer(ephemeral=True)
-        await asyncio.sleep(0.1)
+        await self.on_submit_callback(interaction, self.input.value)
 
-        db_cog = self.bot.get_cog('Database')
-        username = self.username_input.value
-
-        # We will check if the get_player_by_username function is working
-        existing_player = await db_cog.get_player_by_username(username)
-
-        if existing_player:
-            return await interaction.followup.send(
-                f"Sorry, the username `{username}` is already taken. Please try again with a different name.",
-                ephemeral=True
-            )
-
-        gender_view = GenderSelectView(self.bot, interaction.user.id, username)
-        message = await interaction.followup.send(
-            f"Recruit **{username}**! Recruitment Officer Elara acknowledges your application. Please select your adventurer's gender.",
-            view=gender_view,
-            ephemeral=True
-        )
-        gender_view.message = message
-
-# --- GenderSelectView Class ---
-# The logic inside this class is already good. No changes needed.
-class GenderSelectView(discord.ui.View):
-    def __init__(self, bot, user_id, username):
-        super().__init__(timeout=60)
-        self.bot = bot
-        self.user_id = user_id
-        self.username = username
-        self.gender = None
-        self.message = None
-
-    async def interaction_check(self, interaction: discord.Interaction) -> bool:
-        if interaction.user.id != self.user_id:
-            await interaction.response.send_message("This is not your adventure!", ephemeral=True)
-            return False
-        return True
-
-    async def on_timeout(self):
-        if self.message:
-            try:
-                # Edit the message with a clear instruction and remove the buttons
-                await self.message.edit(
-                    content="⏱️ Gender selection timed out. Please run `/start` again to create your character.",
-                    view=None  # This removes all buttons
-                )
-            except discord.NotFound:
-                # If the message is already gone, just ignore the error.
-                # This prevents the traceback from appearing in your console.
-                pass
-
-    async def _create_player(self, interaction: discord.Interaction, gender: str):
-        db_cog = self.bot.get_cog('Database')
-        if not db_cog:
-            return await interaction.edit_original_response(
-                content="Database not loaded. Please contact an administrator.",
-                view=None
-            )
-        try:
-            await db_cog.add_player(
-                user_id=self.user_id,
-                username=self.username,
-                gender=gender
-            )
-            await db_cog.set_game_channel_id(interaction.channel_id)
-            self.gender = gender
-        except Exception as e:
-            print(f"Error creating player: {e}")
-            return await interaction.edit_original_response(
-                content=f"An error occurred while creating your player: {e}",
-                view=None
-            )
-        for item in self.children:
-            item.disabled = True
-        pet_selection_view = StarterPetView(self.bot, self.user_id, self.username, self.gender)
-        await interaction.edit_original_response(
-            content="Recruit, by the authority of the Grand Master, you are now an Adventurer. I bestow upon you this Aethelband. Now, choose your first companion.",
-            view=pet_selection_view
-        )
-        pet_selection_view.message = await interaction.original_response()
-
-    @discord.ui.button(label="Male", style=discord.ButtonStyle.blurple)
-    async def male_button(self, interaction: discord.Interaction, button: discord.ui.Button):
-        await interaction.response.defer()
-        await self._create_player(interaction, "Male")
-
-    @discord.ui.button(label="Female", style=discord.ButtonStyle.red)
-    async def female_button(self, interaction: discord.Interaction, button: discord.ui.Button):
-        await interaction.response.defer()
-        await self._create_player(interaction, "Female")
-
-    @discord.ui.button(label="Other", style=discord.ButtonStyle.grey)
-    async def other_button(self, interaction: discord.Interaction, button: discord.ui.Button):
-        await interaction.response.defer()
-        await self._create_player(interaction, "Other")
-
-# --- StarterPetView Class ---
-# The logic inside this class is already good. No changes needed.
-class StarterPetView(discord.ui.View):
-    def __init__(self, bot, user_id, username, gender):
-        super().__init__(timeout=180)
-        self.bot = bot
-        self.user_id = user_id
-        self.username = username
-        self.gender = gender
-        self.message = None
-        self.selected_pet_data = None
-
-        # --- REFACTOR FIX ---
-        # Use the new STARTER_PETS_LIST we created at the top of the file
-        options = [discord.SelectOption(label=pet['species'], value=pet['species']) for pet in STARTER_PETS_LIST]
-        self.pet_select = discord.ui.Select(placeholder="Choose your starter pet...", options=options)
-        self.pet_select.callback = self.pet_select_callback
-        self.add_item(self.pet_select)
-
-        self.confirm_button = discord.ui.Button(label="Confirm Choice", style=discord.ButtonStyle.green, disabled=True)
-        self.confirm_button.callback = self.confirm_callback
-        self.add_item(self.confirm_button)
-
-    async def interaction_check(self, interaction: discord.Interaction) -> bool:
-        if interaction.user.id != self.user_id:
-            await interaction.response.send_message("This is not your adventure!", ephemeral=True)
-            return False
-        return True
-
-    async def on_timeout(self):
-        if self.message:
-            for item in self.children:
-                item.disabled = True
-            await self.message.edit(content="Pet selection timed out.", view=self)
-
-    async def pet_select_callback(self, interaction: discord.Interaction):
-        await interaction.response.defer()
-        species_name = interaction.data['values'][0]
-        self.selected_pet_data = next((pet for pet in STARTER_PETS_LIST if pet["species"] == species_name), None)
-        stat_ranges = self.selected_pet_data["base_stat_ranges"]
-
-        # --- NEW: Dynamic Color Logic ---
-        PET_TYPE_COLORS = {
-            "Fire": discord.Color.orange(),
-            "Water": discord.Color.blue(),
-            "Ground": discord.Color.green()
-            # You can add more types here later
-        }
-        pet_color = PET_TYPE_COLORS.get(self.selected_pet_data['pet_type'], discord.Color.default())
-
-        embed = discord.Embed(
-            title=f"You've selected the {self.selected_pet_data['species']}!",
-            description=PET_DESCRIPTIONS.get(self.selected_pet_data["species"], "No description."),
-            color=pet_color  # <-- Use the dynamic color
-        )
-
-        embed.set_thumbnail(url=get_pet_image_url(self.selected_pet_data["species"]))
-        embed.add_field(name="Type", value=self.selected_pet_data['pet_type'], inline=True)
-        embed.add_field(name="Personality", value=self.selected_pet_data['personality'], inline=True)
-        stats_display = (f"**HP:** {stat_ranges['hp'][0]}-{stat_ranges['hp'][1]}\n"
-                         f"**Attack:** {stat_ranges['attack'][0]}-{stat_ranges['attack'][1]}\n"
-                         f"**Defense:** {stat_ranges['defense'][0]}-{stat_ranges['defense'][1]}\n"
-                         f"**Sp. Attack:** {stat_ranges['special_attack'][0]}-{stat_ranges['special_attack'][1]}\n"
-                         f"**Sp. Defense:** {stat_ranges['special_defense'][0]}-{stat_ranges['special_defense'][1]}\n"
-                         f"**Speed:** {stat_ranges['speed'][0]}-{stat_ranges['speed'][1]}")
-        embed.add_field(name="Potential Base Stats", value=stats_display, inline=False)
-        self.confirm_button.disabled = False
-        await interaction.edit_original_response(content=f"You have chosen **{self.selected_pet_data['species']}**! Review its potential and confirm.", embed=embed, view=self)
-
-    async def confirm_callback(self, interaction: discord.Interaction):
-        await interaction.response.defer()
-
-        db_cog = self.bot.get_cog('Database')
-        if not self.selected_pet_data:
-            return await interaction.edit_original_response(content="Please select a pet first.", view=self)
-
-        stat_ranges = self.selected_pet_data["base_stat_ranges"]
-        base_stats = {stat: random.randint(val[0], val[1]) for stat, val in stat_ranges.items()}
-
-        starting_skills = self.selected_pet_data.get("skill_tree", {}).get("1", ["scratch"])
-
-        pet_id = await db_cog.add_pet(
-            owner_id=interaction.user.id, name=self.selected_pet_data["species"],
-            species=self.selected_pet_data["species"],
-            description=PET_DESCRIPTIONS.get(self.selected_pet_data["species"], ""),
-            rarity=self.selected_pet_data["rarity"], pet_type=self.selected_pet_data["pet_type"],
-            skills=starting_skills,
-            current_hp=base_stats["hp"], max_hp=base_stats["hp"],
-            attack=base_stats["attack"], defense=base_stats["defense"],
-            special_attack=base_stats["special_attack"], special_defense=base_stats["special_defense"],
-            speed=base_stats["speed"], base_hp=base_stats["hp"],
-            base_attack=base_stats["attack"], base_defense=base_stats["defense"],
-            base_special_attack=base_stats["special_attack"], base_special_defense=base_stats["special_defense"],
-            base_speed=base_stats["speed"]
-        )
-
-        await db_cog.set_main_pet(user_id=interaction.user.id, pet_id=pet_id)
-        await db_cog.add_quest(interaction.user.id, "a_guildsmans_first_steps", {"count": 0})
-
-        # --- ALL FINAL MESSAGE LOGIC IS NOW INSIDE THE TRY BLOCK ---
-        final_embed = discord.Embed(
-            title=f"Welcome to Aethelgard, {self.username}! 🎉",
-            description=f"Your adventure begins now! You are registered as a **{self.gender}** adventurer, and the **Aethelband** is attuned to your first companion.",
-            color=discord.Color.green()
-        )
-        final_embed.set_thumbnail(url=get_pet_image_url(self.selected_pet_data["species"]))
-        final_embed.add_field(name=f"Your First Companion: {self.selected_pet_data['species']}",
-                                value=PET_DESCRIPTIONS.get(self.selected_pet_data["species"], ""), inline=False)
-        stats_text = (f"HP: {base_stats['hp']} | Atk: {base_stats['attack']} | Def: {base_stats['defense']}\n"
-                        f"Sp. Atk: {base_stats['special_attack']} | Sp. Def: {base_stats['special_defense']} | Spd: {base_stats['speed']}")
-        final_embed.add_field(name="Your Pet's Base Stats", value=stats_text, inline=False)
-
-        player_and_pet_data = await db_cog.get_player_and_pet_data(self.user_id)
-        if player_and_pet_data:
-            status_bar = get_status_bar(player_and_pet_data['player_data'], player_and_pet_data['main_pet_data'])
-            final_embed.set_footer(text=status_bar)
-
-        talent_view = TalentChoiceView(self.bot, self.user_id, pet_id, self.selected_pet_data['species'],
-                                        final_embed)
-        await interaction.edit_original_response(
-            content="An excellent choice. I can sense a particular talent awakening within your new partner. Choose a talent from the dropdown below to shape its future.",
-            embed=None,
-            view=talent_view
-        )
-        self.stop()
-
-# --- TalentChoiceView Class ---
-# The logic inside this class is already good. No changes needed.
-class TalentChoiceView(discord.ui.View):
-    def __init__(self, bot, user_id, pet_id, pet_species, final_embed):
-        super().__init__(timeout=180)
-        self.bot = bot
-        self.user_id = user_id
-        self.pet_id = pet_id
-        self.pet_species = pet_species
-        self.final_embed = final_embed
-
-        # --- THIS IS THE NEW UI LOGIC ---
-        # Get the list of talents for the chosen starter pet
-        talents = STARTER_TALENTS.get(self.pet_species, [])
-
-        # Create a list of SelectOptions for the dropdown
-        options = [
-            discord.SelectOption(
-                label=talent['name'],
-                # Use the mechanic description to explain what the talent does
-                description=talent['mechanic_desc'][:100],  # Descriptions are limited to 100 characters
-                value=talent['mechanic_name']  # Store the mechanic name in the value
-            ) for talent in talents
-        ]
-
-        # Create the dropdown (Select) component
-        talent_select = discord.ui.Select(
-            placeholder="Choose your pet's Innate Talent...",
-            options=options
-        )
-        talent_select.callback = self.talent_select_callback
-        self.add_item(talent_select)
-
-    async def interaction_check(self, interaction: discord.Interaction) -> bool:
-        if interaction.user.id != self.user_id:
-            await interaction.response.send_message("This is not your adventure!", ephemeral=True)
-            return False
-        return True
-
-    async def on_timeout(self):
-        if self.message:
-            for item in self.children:
-                item.disabled = True
-            await self.message.edit(content="Talent selection timed out.", view=self)
-
-    async def talent_select_callback(self, interaction: discord.Interaction):
-        await interaction.response.defer()
-        chosen_passive_name = interaction.data['values'][0]
-
-        db_cog = self.bot.get_cog('Database')
-        await db_cog.update_pet(self.pet_id, passive_ability=chosen_passive_name)
-        chosen_talent = next(
-            (t for t in STARTER_TALENTS[self.pet_species] if t['mechanic_name'] == chosen_passive_name), None)
-
-        # --- THIS IS THE CORRECTED QUEST GRANTING LOGIC ---
-        quest_id = "a_guildsmans_first_steps"
-        await db_cog.add_quest(self.user_id, quest_id)
-        # Talking to Elara during /start IS the first objective, so we complete it.
-        await db_cog.update_quest_progress(self.user_id, quest_id, {'status': 'in_progress', 'count': 1})
-
-        # Add the talent info to the embed
-        self.final_embed.add_field(
-            name=f"Innate Talent: {chosen_talent['name']}",
-            value=f"_{chosen_talent['mechanic_desc']}_",
-            inline=False
-        )
-
-        # We also add the mechanic's description to the final embed for clarity
-        self.final_embed.add_field(
-            name="Talent Effect",
-            value=chosen_talent['mechanic_desc'],
-            inline=False
-        )
-
-        # Add the completed objective and the new, clear objective
-        self.final_embed.add_field(
-            name="✅ Quest Started",
-            value="Recruitment Officer Elara has given you your first task.",
-            inline=False
-        )
-        self.final_embed.add_field(
-            name="New Objective",
-            value="Use /adventure command and gather a **Sun-Kissed Berry** from the wilds.",
-            inline=False
-        )
-        # --- END OF CORRECTED LOGIC ---
-
-        await interaction.edit_original_response(
-            content="Your companion's talent has awakened! Your adventure begins now.",
-            embed=self.final_embed,
-            view=None
-        )
-        await asyncio.sleep(15)
-        await interaction.delete_original_response()
-        self.stop()
-
-
-# --- The Main Cog ---
 class Game(commands.Cog):
-    def __init__(self, bot):
+    def __init__(self, bot: commands.Bot):
         self.bot = bot
 
-    @app_commands.command(name='start', description='Begin your journey as a Guild Adventurer!')
-    async def start_adventure(self, interaction: discord.Interaction):
-        db_cog = self.bot.get_cog('Database')
-        if not db_cog:
-            return await interaction.response.send_message(
-                "Database is not loaded. Please contact an administrator.",
-                ephemeral=True
-            )
-        player_and_pet_data = await db_cog.get_player_and_pet_data(interaction.user.id)
-        player_data = player_and_pet_data['player_data'] if player_and_pet_data else None
-        if player_data and player_data.get('main_pet_id'):
-            return await interaction.response.send_message(
-                    "You have already started your adventure! Use `/adventure` to open your menu.",
-                    ephemeral=True
-            )
-        if player_data:
-            username = player_data.get('username')
-            gender = player_data.get('gender')
-            pet_selection_view = StarterPetView(self.bot, interaction.user.id, username, gender)
-            await interaction.response.send_message(
-                    "It seems you have not chosen a starter pet yet. Please select your first companion.",
-                    view=pet_selection_view,
-                    ephemeral=True
-                )
-            pet_selection_view.message = await interaction.original_response()
+    # ---------- Session message helpers (one message UI) ----------
+
+    async def _ensure_session_message(self, interaction: discord.Interaction) -> int:
+        """Return the session message id, creating it if needed."""
+        user_id = interaction.user.id
+        repo = self.bot.repo
+        msg_id = await repo.get_session_message_id(user_id)
+        if msg_id:
+            return msg_id
+
+        # We already deferred in /start; create the initial ephemeral message now.
+        await interaction.edit_original_response(content="…")
+        msg = await interaction.original_response()
+        await repo.set_session_message_id(user_id, msg.id)
+        return msg.id
+
+    async def _edit_session(self, interaction: discord.Interaction, *, content: str, view: discord.ui.View | None):
+        """Edit the persistent session message regardless of interaction type."""
+        msg_id = await self._ensure_session_message(interaction)
+        await interaction.followup.edit_message(msg_id, content=content, view=view)
+
+    # ---------- Story rendering ----------
+
+    async def _render_story(self, interaction: discord.Interaction, *, force_step_id: str | None = None):
+        user_id = interaction.user.id
+        repo = self.bot.repo
+        narrative = self.bot.narratives["section_0"]
+
+        # Ensure player exists
+        player = await repo.get_player(user_id)
+        if not player:
+            first_step = narrative.first_step_id()
+            await repo.create_player(user_id, {
+                "name": interaction.user.display_name,
+                "section_id": "section_0",
+                "story_step_id": first_step,
+                "energy": 10,
+                "max_energy": 10,
+            })
+            player = await repo.get_player(user_id)
+
+        state = await repo.get_story_state(user_id)
+        step_id = force_step_id or state["story_step_id"]
+        step = narrative.get_step(step_id)
+
+        def render_text(t: str) -> str:
+            if not t:
+                return ""
+            return t.replace("{player_name}", player.get("name") or interaction.user.display_name)
+
+        # --- NARRATION ---
+        if step.get("type") == "narration":
+            text = render_text(step.get("text", ""))
+            next_id = step.get("next")
+
+            if not next_id:
+                await self._edit_session(interaction, content=text, view=None)
+                return
+
+            view = discord.ui.View(timeout=120)
+            btn = discord.ui.Button(label="Continue", style=discord.ButtonStyle.primary)
+
+            async def on_click(inter: discord.Interaction, to_next=next_id, current_step=step):
+                # Look ahead: if next is a modal, DO NOT defer; show modal directly.
+                nxt_step = narrative.get_step(to_next)
+                if nxt_step.get("type") == "modal":
+                    await narrative.apply_effects(user_id, current_step.get("effects"))
+                    await repo.set_story_state(user_id, "section_0", to_next)
+                    await self._render_story(inter, force_step_id=to_next)
+                    return
+
+                # Non-modal: safe to defer, then render next step
+                await inter.response.defer(ephemeral=True)
+                await narrative.apply_effects(user_id, current_step.get("effects"))
+                await repo.set_story_state(user_id, "section_0", to_next)
+                await self._render_story(inter, force_step_id=to_next)
+
+            btn.callback = on_click
+            view.add_item(btn)
+            await self._edit_session(interaction, content=text, view=view)
             return
-        modal = StartModal(self.bot)
-        await interaction.response.send_modal(modal)
+
+        # --- MODAL (e.g., name input) ---
+        if step.get("type") == "modal":
+            title = step.get("modal_title", "Enter Name")
+            label = step.get("modal_label", "Name")
+            min_len = int(step.get("modal_min", 2))
+            max_len = int(step.get("modal_max", 16))
+            next_id = step.get("next")
+
+            # IMPORTANT: do NOT defer before sending a modal
+            self_outer = self
+            narrative_outer = narrative
+            repo_outer = repo
+
+            class NameModal(discord.ui.Modal):
+                def __init__(self, _title, _label, _min, _max):
+                    super().__init__(title=_title, timeout=120)
+                    self.input = discord.ui.TextInput(
+                        label=_label, placeholder="Enter your name",
+                        min_length=_min, max_length=_max, required=True
+                    )
+                    self.add_item(self.input)
+
+                async def on_submit(self, inter: discord.Interaction):
+                    # We are now in the modal submit interaction → defer then follow-up edit
+                    await inter.response.defer(ephemeral=True)
+                    await narrative_outer.apply_effects(user_id, step.get("effects"), modal_value=self.input.value)
+                    if next_id:
+                        await repo_outer.set_story_state(user_id, "section_0", next_id)
+                        await self_outer._render_story(inter, force_step_id=next_id)
+                    else:
+                        await self_outer._edit_session(inter, content="Name saved.", view=None)
+
+            await interaction.response.send_modal(NameModal(title, label, min_len, max_len))
+            return
+
+        # --- CHOICE (e.g., starter selection) ---
+        if step.get("type") == "choice":
+            prompt = render_text(step.get("prompt", "Choose:"))
+            view = discord.ui.View(timeout=120)
+
+            for opt in step.get("options", []):
+                label = opt["label"]
+                eff = opt.get("effects")
+                to_next = opt.get("next") or step.get("next") or step_id
+
+                button = discord.ui.Button(label=label, style=discord.ButtonStyle.primary)
+
+                async def handler(inter: discord.Interaction, eff_=eff, next_id_=to_next):
+                    nxt_step = narrative.get_step(next_id_)
+                    if nxt_step.get("type") == "modal":
+                        await narrative.apply_effects(user_id, eff_)
+                        await repo.set_story_state(user_id, "section_0", next_id_)
+                        await self._render_story(inter, force_step_id=next_id_)
+                        return
+
+                    await inter.response.defer(ephemeral=True)
+                    await narrative.apply_effects(user_id, eff_)
+                    await repo.set_story_state(user_id, "section_0", next_id_)
+                    await self._render_story(inter, force_step_id=next_id_)
+
+                button.callback = handler
+                view.add_item(button)
+
+            await self._edit_session(interaction, content=prompt, view=view)
+            return
+
+        # --- DYNAMIC CHOICE (e.g., starter talents) ---
+        if step.get("type") == "dyn_choice":
+            prompt = render_text(step.get("prompt", "Choose:"))
+            view = discord.ui.View(timeout=120)
+
+            # Read selected starter from flags (starter_pet:<Name>)
+            player = await repo.get_player(user_id)
+            flags = player.get("flags", set())
+            if not isinstance(flags, set):
+                flags = set(flags or [])
+            starter = next((f.split(":", 1)[1] for f in flags
+                            if isinstance(f, str) and f.startswith("starter_pet:")), None)
+
+            talents = STARTER_TALENTS.get(starter, [])
+            if not talents:
+                await self._edit_session(interaction, content="No talents available for your starter.", view=None)
+                return
+
+            for t in talents:
+                label = t["name"]
+                mech = t.get("mechanic_name", label)
+
+                button = discord.ui.Button(label=label, style=discord.ButtonStyle.primary)
+
+                async def handler(inter: discord.Interaction, mech_=mech):
+                    await inter.response.defer(ephemeral=True)
+                    await narrative.apply_effects(
+                        user_id, [{"op": "set_flag", "flag": f"starter_talent:{mech_}"}]
+                    )
+                    next_id = step.get("next") or step_id
+                    await repo.set_story_state(user_id, "section_0", next_id)
+                    await self._render_story(inter, force_step_id=next_id)
+
+                button.callback = handler
+                view.add_item(button)
+
+            await self._edit_session(interaction, content=prompt, view=view)
+            return
+
+        # --- Fallback ---
+        await self._edit_session(interaction, content="⚠️ This part of the story is under construction.", view=None)
+
+    # ---------- Slash command ----------
+
+    @app_commands.command(name="start", description="Begin your adventure.")
+    async def start(self, interaction: discord.Interaction):
+        # Create the ephemeral session message; subsequent steps edit it
+        await interaction.response.defer(ephemeral=True)
+        await self._render_story(interaction)
+
 
 async def setup(bot):
     await bot.add_cog(Game(bot))

--- a/core/narrative.py
+++ b/core/narrative.py
@@ -1,0 +1,61 @@
+# core/narrative.py
+from __future__ import annotations
+from typing import Dict, Any, List, Optional
+from .repository import Repository
+
+class Narrative:
+    def __init__(self, story: Dict[str, Any], repo: Repository):
+        self.story = story
+        self.repo = repo
+        self._steps = {s["id"]: s for s in story.get("steps", [])}
+
+    def first_step_id(self) -> str:
+        return self.story.get("steps", [])[0]["id"]
+
+    def get_step(self, step_id: str) -> Dict[str, Any]:
+        step = self._steps.get(step_id)
+        if not step:
+            # Graceful fallback for missing content
+            return {"id": "missing", "type": "narration",
+                    "text": "⚠️ This part of the story is under construction."}
+        return step
+
+    async def apply_effects(self, user_id: int, effects: Optional[List[Dict[str, Any]]], *, modal_value: str | None = None):
+        for eff in effects or []:
+            op = eff.get("op")
+
+            if op == "grant_pet":
+                await self.repo.add_pet(user_id, eff["pet_id"])
+
+            elif op == "grant_item":
+                await self.repo.add_item(user_id, eff["item_id"], eff.get("qty", 1))
+
+            elif op == "set_flag":
+                await self.repo.set_flag(user_id, eff["flag"])
+
+            elif op == "set_name_from_modal":
+                # pull the text the user typed in the modal
+                if modal_value:
+                    await self.repo.update_player_name(user_id, modal_value)
+
+            elif op == "set_main_pet_by_species":
+                # optional op: set player's main pet to the first pet matching species
+                await self.repo.set_main_pet_by_species(user_id, eff["pet_id"])
+            # Add more ops over time; engine stays the same.
+
+    async def choose(self, user_id: int, current_step_id: str, choice_id: str) -> str:
+        step = self.get_step(current_step_id)
+        if step.get("type") != "choice":
+            return current_step_id  # no-op
+
+        # find selected option
+        chosen = next((o for o in step.get("options", []) if o["id"] == choice_id), None)
+        if not chosen:
+            return current_step_id
+
+        await self.apply_effects(user_id, chosen.get("effects"))
+
+        # next step resolution: prefer option.next, else step.next, else stay
+        next_id = chosen.get("next") or step.get("next") or current_step_id
+        await self.repo.set_story_state(user_id, self.story["id"], next_id)
+        return next_id

--- a/core/repository.py
+++ b/core/repository.py
@@ -1,0 +1,205 @@
+# core/repository.py
+from __future__ import annotations
+from typing import Protocol, Dict, Any, List, Optional, Set
+import asyncio
+
+# ---------- Protocol (engine uses only this) ----------
+class Repository(Protocol):
+    async def get_player(self, user_id: int) -> Optional[Dict[str, Any]]: ...
+    async def create_player(self, user_id: int, defaults: Dict[str, Any]) -> Dict[str, Any]: ...
+    async def save_player(self, user_id: int, data: Dict[str, Any]) -> None: ...
+    async def add_item(self, user_id: int, item_id: str, qty: int = 1) -> None: ...
+    async def add_pet(self, user_id: int, pet_id: str) -> None: ...
+    async def set_flag(self, user_id: int, flag: str) -> None: ...
+    async def get_story_state(self, user_id: int) -> Dict[str, Any]: ...
+    async def set_story_state(self, user_id: int, section_id: str, step_id: str) -> None: ...
+
+# ---------- In-memory (dev / tests) ----------
+class MemoryRepository:
+    def __init__(self):
+        self.players: Dict[int, Dict[str, Any]] = {}
+    async def update_player_name(self, user_id: int, name: str) -> None:
+        p = self.players[user_id]
+        p["name"] = name
+
+    async def set_main_pet_by_species(self, user_id: int, pet_species: str) -> None:
+        p = self.players[user_id]
+        for pet in p["pets"]:
+            if pet.get("pet_id") == pet_species:
+                p["main_pet_id"] = pet_species
+                return
+    async def get_player(self, user_id: int) -> Optional[Dict[str, Any]]:
+        return self.players.get(user_id)
+
+    async def create_player(self, user_id: int, defaults: Dict[str, Any]) -> Dict[str, Any]:
+        self.players[user_id] = {
+            "id": user_id,
+            "name": defaults.get("name", f"Adventurer {user_id}"),
+            "section_id": defaults.get("section_id", "section_0"),
+            "story_step_id": defaults.get("story_step_id", "intro_1"),
+            "flags": set(defaults.get("flags", [])),
+            "inventory": [],
+            "pets": [],
+            "energy": defaults.get("energy", 10),
+            "warp_unlocks": set(),
+        }
+        return self.players[user_id]
+
+    async def save_player(self, user_id: int, data: Dict[str, Any]) -> None:
+        if user_id not in self.players:
+            await self.create_player(user_id, data)
+        else:
+            self.players[user_id].update(data)
+
+    async def add_item(self, user_id: int, item_id: str, qty: int = 1) -> None:
+        p = self.players[user_id]
+        inv = p["inventory"]
+        for it in inv:
+            if it["item_id"] == item_id:
+                it["qty"] += qty
+                break
+        else:
+            inv.append({"item_id": item_id, "qty": qty})
+
+    async def add_pet(self, user_id: int, pet_id: str) -> None:
+        p = self.players[user_id]
+        p["pets"].append({"pet_id": pet_id, "nickname": None})
+
+    async def set_flag(self, user_id: int, flag: str) -> None:
+        self.players[user_id]["flags"].add(flag)
+
+    async def get_story_state(self, user_id: int) -> Dict[str, Any]:
+        p = self.players[user_id]
+        return {"section_id": p["section_id"], "story_step_id": p["story_step_id"]}
+
+    async def set_story_state(self, user_id: int, section_id: str, step_id: str) -> None:
+        p = self.players[user_id]
+        p["section_id"] = section_id
+        p["story_step_id"] = step_id
+
+    async def get_session_message_id(self, user_id: int) -> int | None:
+        return self.players[user_id].get("session_message_id")
+
+    async def set_session_message_id(self, user_id: int, message_id: int) -> None:
+        self.players[user_id]["session_message_id"] = int(message_id)
+
+# ---------- Your real DB repo (skeleton) ----------
+class SqlRepository:
+    def __init__(self, pool):
+        self.pool = pool
+
+    async def update_player_name(self, user_id: int, name: str) -> None:
+        async with self.pool.acquire() as con:
+            await con.execute(
+                "UPDATE players SET username=$2 WHERE user_id=$1",
+                user_id, name
+            )
+
+    async def set_main_pet_by_species(self, user_id: int, pet_species: str) -> None:
+        async with self.pool.acquire() as con:
+            pet_row = await con.fetchrow(
+                "SELECT pet_id FROM pets WHERE owner_id=$1 AND species=$2 ORDER BY pet_id ASC LIMIT 1",
+                user_id, pet_species
+            )
+            if pet_row:
+                await con.execute(
+                    "UPDATE players SET main_pet_id=$2 WHERE user_id=$1",
+                    user_id, pet_row["pet_id"]
+                )
+
+    async def get_player(self, user_id: int):
+        async with self.pool.acquire() as con:
+            row = await con.fetchrow(
+                """SELECT user_id, username, section_id, story_step_id,
+                          current_energy, max_energy, main_pet_id
+                   FROM players WHERE user_id=$1""",
+                user_id,
+            )
+            if not row:
+                return None
+            flags = {r["flag"] for r in await con.fetch(
+                "SELECT flag FROM player_flags WHERE player_id=$1", user_id
+            )}
+            return {
+                "id": row["user_id"],
+                "name": row["username"],
+                "section_id": row["section_id"],
+                "story_step_id": row["story_step_id"],
+                "energy": row["current_energy"],
+                "max_energy": row["max_energy"],
+                "main_pet_id": row["main_pet_id"],
+                "flags": flags,
+            }
+
+    async def create_player(self, user_id: int, defaults: dict):
+        async with self.pool.acquire() as con:
+            await con.execute(
+                """INSERT INTO players (user_id, username, section_id, story_step_id, current_energy, max_energy)
+                   VALUES ($1, $2, $3, $4, $5, $6)
+                   ON CONFLICT (user_id) DO NOTHING""",
+                user_id,
+                defaults.get("name", f"Adventurer {user_id}"),
+                defaults.get("section_id", "section_0"),
+                defaults.get("story_step_id", "intro_1"),
+                defaults.get("energy", 10),
+                defaults.get("max_energy", 10),
+            )
+        return await self.get_player(user_id)
+
+    async def save_player(self, user_id: int, data: dict):
+        async with self.pool.acquire() as con:
+            await con.execute(
+                "UPDATE players SET name=$2, section_id=$3, story_step_id=$4, energy=$5 WHERE id=$1",
+                user_id, data.get("name"), data.get("section_id"), data.get("story_step_id"), data.get("energy", 10)
+            )
+
+    async def add_item(self, user_id: int, item_id: str, qty: int = 1):
+        async with self.pool.acquire() as con:
+            await con.execute(
+                """INSERT INTO inventory (player_id, item_id, qty)
+                   VALUES ($1, $2, $3)
+                   ON CONFLICT (player_id, item_id) DO UPDATE SET qty = inventory.qty + EXCLUDED.qty""",
+                user_id, item_id, qty
+            )
+
+    async def add_pet(self, user_id: int, pet_id: str):
+        async with self.pool.acquire() as con:
+            await con.execute(
+                "INSERT INTO pets (player_id, pet_id) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+                user_id, pet_id
+            )
+
+    async def set_flag(self, user_id: int, flag: str):
+        async with self.pool.acquire() as con:
+            await con.execute(
+                "INSERT INTO player_flags (player_id, flag) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+                user_id, flag
+            )
+
+    async def get_story_state(self, user_id: int):
+        async with self.pool.acquire() as con:
+            row = await con.fetchrow(
+                "SELECT section_id, story_step_id FROM players WHERE user_id = $1",
+                user_id,
+            )
+            return dict(row) if row else {"section_id": "section_0", "story_step_id": "intro_1"}
+
+    async def set_story_state(self, user_id: int, section_id: str, step_id: str):
+        async with self.pool.acquire() as con:
+            await con.execute(
+                "UPDATE players SET section_id = $2, story_step_id = $3 WHERE user_id = $1",
+                user_id, section_id, step_id
+            )
+
+    async def get_session_message_id(self, user_id: int) -> int | None:
+        async with self.pool.acquire() as con:
+            return await con.fetchval(
+                "SELECT session_message_id FROM players WHERE user_id=$1", user_id
+            )
+
+    async def set_session_message_id(self, user_id: int, message_id: int) -> None:
+        async with self.pool.acquire() as con:
+            await con.execute(
+                "UPDATE players SET session_message_id=$2 WHERE user_id=$1",
+                user_id, int(message_id)
+            )

--- a/core/validator.py
+++ b/core/validator.py
@@ -1,0 +1,100 @@
+# core/validator.py
+from __future__ import annotations
+from typing import Dict, Any, List, Set
+
+ALLOWED_TYPES: Set[str] = {"narration", "choice", "modal", "dyn_choice"}
+
+def _is_str(x) -> bool:
+    return isinstance(x, str) and len(x) > 0
+
+def validate_story(story: Dict[str, Any]) -> List[str]:
+    errors: List[str] = []
+
+    if not isinstance(story, dict):
+        return ["story must be a dict"]
+
+    if not _is_str(story.get("id")):
+        errors.append("story missing or invalid 'id'")
+
+    steps = story.get("steps", [])
+    if not isinstance(steps, list) or not steps:
+        errors.append("story 'steps' must be a non-empty list")
+        return errors
+
+    seen_ids: Set[str] = set()
+    target_ids: List[str] = []
+
+    for s in steps:
+        sid = s.get("id")
+        if not _is_str(sid):
+            errors.append("step missing 'id'")
+            continue
+        if sid in seen_ids:
+            errors.append(f"duplicate step id: {sid}")
+        seen_ids.add(sid)
+
+        stype = s.get("type")
+        if stype not in ALLOWED_TYPES:
+            errors.append(f"step {sid} has invalid type: {stype}")
+            continue
+
+        # Common: validate 'next' if present
+        nxt = s.get("next")
+        if nxt is not None and not _is_str(nxt):
+            errors.append(f"step {sid} has non-string 'next'")
+        if _is_str(nxt):
+            target_ids.append(nxt)
+
+        if stype == "narration":
+            if not _is_str(s.get("text")):
+                errors.append(f"step {sid} (narration) missing 'text'")
+
+        elif stype == "choice":
+            options = s.get("options")
+            if not isinstance(options, list) or not options:
+                errors.append(f"choice step {sid} missing non-empty 'options'")
+            else:
+                for i, opt in enumerate(options):
+                    if not _is_str(opt.get("id")):
+                        errors.append(f"choice step {sid} option {i} missing 'id'")
+                    if not _is_str(opt.get("label")):
+                        errors.append(f"choice step {sid} option {i} missing 'label'")
+                    opt_next = opt.get("next")
+                    if opt_next is not None and not _is_str(opt_next):
+                        errors.append(f"choice step {sid} option {i} has non-string 'next'")
+                    if _is_str(opt_next):
+                        target_ids.append(opt_next)
+
+        elif stype == "modal":
+            # minimal requirements for name modal
+            if not _is_str(s.get("modal_title")):
+                errors.append(f"modal step {sid} missing 'modal_title'")
+            if not _is_str(s.get("modal_label")):
+                errors.append(f"modal step {sid} missing 'modal_label'")
+            # next is recommended (where to go after submit)
+            if not _is_str(s.get("next")):
+                errors.append(f"modal step {sid} should define a 'next'")
+
+        elif stype == "dyn_choice":
+            if not _is_str(s.get("prompt")):
+                errors.append(f"dyn_choice step {sid} missing 'prompt'")
+            if not _is_str(s.get("dynamic_source")):
+                errors.append(f"dyn_choice step {sid} missing 'dynamic_source'")
+            # usually should define next
+            if not _is_str(s.get("next")):
+                errors.append(f"dyn_choice step {sid} should define a 'next'")
+
+    # cross-reference: every referenced 'next' must exist
+    missing_targets = [t for t in target_ids if t not in seen_ids]
+    for t in missing_targets:
+        errors.append(f"'next' references missing step id: {t}")
+
+    return errors
+
+
+def validate_all() -> None:
+    # Import here to avoid circulars
+    from data.section_0.story import STORY
+    problems = validate_story(STORY)
+    if problems:
+        raise ValueError("Data validation failed:\n- " + "\n- ".join(problems))

--- a/data/section_0/story.py
+++ b/data/section_0/story.py
@@ -1,0 +1,78 @@
+# data/section_0/story.py
+
+STORY = {
+    "id": "section_0",
+    "title": "Prologue: Oakhaven",
+    "steps": [
+        {
+            "id": "intro_1",
+            "type": "narration",
+            "text": "You wake in Oakhaven’s guild hall to the distant roll of thunder...",
+            "next": "name_prompt"
+        },
+
+        {
+            "id": "name_prompt",
+            "type": "modal",                       # <-- will open a modal
+            "modal_title": "Choose your guild name",
+            "modal_label": "Name",
+            "modal_min": 2,
+            "modal_max": 16,
+            "effects": [{"op": "set_name_from_modal"}],   # engine will read modal value
+            "next": "name_ack"
+        },
+
+        {
+            "id": "name_ack",
+            "type": "narration",
+            "text": "Welcome, {player_name}.",
+            "next": "choose_starter"
+        },
+
+        {
+            "id": "choose_starter",
+            "type": "choice",
+            "prompt": "A companion approaches. Who will you bond with?",
+            "options": [
+                {"id": "pet_pyrelisk", "label": "Pyrelisk",
+                 "effects": [
+                     {"op": "grant_pet", "pet_id": "Pyrelisk"},
+                     {"op": "set_main_pet_by_species", "pet_id": "Pyrelisk"},
+                     {"op": "set_flag", "flag": "starter_pet:Pyrelisk"}
+                 ],
+                 "next": "choose_talent"},
+
+                {"id": "pet_dewdrop", "label": "Dewdrop",
+                 "effects": [
+                     {"op": "grant_pet", "pet_id": "Dewdrop"},
+                     {"op": "set_main_pet_by_species", "pet_id": "Dewdrop"},
+                     {"op": "set_flag", "flag": "starter_pet:Dewdrop"}
+                 ],
+                 "next": "choose_talent"},
+
+                {"id": "pet_terran", "label": "Terran",
+                 "effects": [
+                     {"op": "grant_pet", "pet_id": "Terran"},
+                     {"op": "set_main_pet_by_species", "pet_id": "Terran"},
+                     {"op": "set_flag", "flag": "starter_pet:Terran"}
+                 ],
+                 "next": "choose_talent"}
+            ]
+        },
+
+        {
+            "id": "choose_talent",
+            "type": "dyn_choice",                  # <-- dynamic options (from data)
+            "prompt": "Select a talent for your starter.",
+            "dynamic_source": "starter_talents",   # we'll resolve from data
+            "pet_flag_key": "starter_pet",
+            "next": "intro_3"
+        },
+
+        {
+            "id": "intro_3",
+            "type": "narration",
+            "text": "With your companion by your side, the guildmaster nods approvingly.\nYour journey begins.",
+        }
+    ]
+}

--- a/migrations/007_add_story_progress.py
+++ b/migrations/007_add_story_progress.py
@@ -1,0 +1,23 @@
+# migrations/007_add_story_progress.py
+
+async def apply(conn):
+    """
+    Migration 007: Add story progress fields to players for Section 0 (and beyond).
+    Postgres (asyncpg) style.
+    """
+
+    async def column_exists(table: str, column: str) -> bool:
+        q = """
+        SELECT EXISTS (
+            SELECT FROM information_schema.columns
+            WHERE table_name = $1 AND column_name = $2
+        );
+        """
+        return await conn.fetchval(q, table, column)
+
+    if not await column_exists('players', 'session_message_id'):
+        await conn.execute("ALTER TABLE players ADD COLUMN session_message_id BIGINT")
+
+    # optional: backfill or normalize values if needed
+    # e.g., set all existing players to tutorial start:
+    # await conn.execute("UPDATE players SET section_id = 'section_0', story_step_id = 'intro_1' WHERE section_id IS NULL OR story_step_id IS NULL")


### PR DESCRIPTION
- game(cog): refactor /start into a single persistent ephemeral session; add Continue, starter, and dynamic talent steps.
- engine(narrative): support new effect ops: set_name_from_modal, set_main_pet_by_species; accept modal/dyn_choice.
- repo(sql/memory): add update_player_name(), set_main_pet_by_species(); expose player flags; (memory) implementations.
- data(section_0): add name modal → starter choice → talent (dynamic) flow; tweak starter species.
- validator: allow 'modal' and 'dyn_choice' step types with field checks.
- bot: GuildBot with setup_hook; load database first; global-only command sync; clear old guild commands once.

This tags our last “pure Discord UI” milestone before scaffolding the PWA/API.