### PR TITLE
feat(prologue): playable tutorial demo (API + DB + web client)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,2 +1,5 @@
 # Replace the password/DB name to match your local Postgres
 DATABASE_URL=postgresql://postgres:password@127.0.0.1:5432/aethelgard_db
+
+# Comma-separated list
+CORS_ORIGINS=http://localhost:5173,http://127.0.0.1:5173,http://localhost:5174,http://127.0.0.1:5174

--- a/core/narrative.py
+++ b/core/narrative.py
@@ -41,6 +41,11 @@ class Narrative:
             elif op == "set_main_pet_by_species":
                 # optional op: set player's main pet to the first pet matching species
                 await self.repo.set_main_pet_by_species(user_id, eff["pet_id"])
+
+            elif op == "goto":
+                # effects: {"op":"goto", "section":"section_1", "step":"intro_1"}
+                await self.repo.set_story_state(user_id, eff["section"], eff["step"])
+
             # Add more ops over time; engine stays the same.
 
     async def choose(self, user_id: int, current_step_id: str, choice_id: str) -> str:

--- a/data/section_0/story.py
+++ b/data/section_0/story.py
@@ -73,6 +73,51 @@ STORY = {
             "id": "intro_3",
             "type": "narration",
             "text": "With your companion by your side, the guildmaster nods approvingly.\nYour journey begins.",
+            "next": "hub_1"
+        },
+
+        # --- simple "town hub" loop for testing ---
+        {
+            "id": "hub_1",
+            "type": "choice",
+            "prompt": "You're in Oakhaven's guild hall. What do you do?",
+            "options": [
+                {"id": "hub_gm", "label": "Talk to the guildmaster", "next": "hub_gm_say"},
+                {"id": "hub_market", "label": "Visit the market", "next": "hub_market_say"},
+                {"id": "hub_training", "label": "Training yard", "next": "hub_training_say"},
+
+                # Put effects here (on the option), not on the next narration.
+                {"id": "hub_end", "label": "Call it a day (end demo)",
+                 "effects": [
+                     {"op": "set_flag", "flag": "finished_tutorial"},
+                     {"op": "goto", "section": "section_1", "step": "intro_1"}
+                 ],
+                 "next": "hub_end_say"}
+            ]
+        },
+        {
+            "id": "hub_gm_say",
+            "type": "narration",
+            "text": "The guildmaster reviews a stack of requests. \"Come back tomorrow—more work will be posted.\"",
+            "next": "hub_1"
+        },
+        {
+            "id": "hub_market_say",
+            "type": "narration",
+            "text": "Vendors haggle, blades glitter, and a baker hands you a sample roll. Tastes like hope.",
+            "next": "hub_1"
+        },
+        {
+            "id": "hub_training_say",
+            "type": "narration",
+            "text": "You stretch and run drills with your companion. Spirits high; muscles burning—good burn.",
+            "next": "hub_1"
+        },
+        {
+            "id": "hub_end_say",
+            "type": "narration",
+            "text": "You call it a day. Thanks for testing this early build!"
+            # no next — ends demo cleanly
         }
     ]
 }


### PR DESCRIPTION
- API: switch to SqlRepository when DATABASE_URL is set; memory fallback
- DB: minimal schema + helper (scripts/patch_min_schema.py); players.main_pet_species; player_flags; pets(species TEXT); indexes
- Narrative: section_0 flow (name modal → starter choice → dynamic talent → hub loop)
- Repo: add_pet() stores species TEXT; set_main_pet_by_species() helper
- CORS: allow Vite dev (localhost/127.0.0.1:5173,5174) + env-based CORS_ORIGINS
- Web: Vite React + TS dev app (apps/web/src/App.tsx) • handles narration/modal/choice/dyn_choice, errors, debug panel • UID via query/localStorage; session reset; /player/state header
- Scripts: scripts/submit_name.py test driver
- Deps: pin FastAPI/Starlette/Pydantic/asyncpg/uvicorn
- Examples: apps/api/.env.example, apps/web/src/.env.local.example
- Gitignore: ignore .env/.env.local, node_modules, dist, etc.