### PR TITLE
feat(hub): add rest action + energy helpers; surface live player state

### DIFF
--- a/core/narrative.py
+++ b/core/narrative.py
@@ -46,6 +46,16 @@ class Narrative:
                 # effects: {"op":"goto", "section":"section_1", "step":"intro_1"}
                 await self.repo.set_story_state(user_id, eff["section"], eff["step"])
 
+            elif op == "restore_energy_full":
+                await self.repo.restore_energy_full(user_id)
+
+            elif op == "spend_energy":
+                amt = int(eff.get("amount", 1))
+                ok = await self.repo.spend_energy(user_id, amt)
+                if not ok:
+                    # Soft failure: mark a flag so the step text can acknowledge it if desired
+                    await self.repo.set_flag(user_id, "no_energy")
+
             # Add more ops over time; engine stays the same.
 
     async def choose(self, user_id: int, current_step_id: str, choice_id: str) -> str:

--- a/data/section_0/story.py
+++ b/data/section_0/story.py
@@ -85,6 +85,7 @@ STORY = {
                 {"id": "hub_gm", "label": "Talk to the guildmaster", "next": "hub_gm_say"},
                 {"id": "hub_market", "label": "Visit the market", "next": "hub_market_say"},
                 {"id": "hub_training", "label": "Training yard", "next": "hub_training_say"},
+                {"id": "hub_rest", "label": "Rest at the bunks (restore energy)", "next": "hub_rest_say"},
 
                 # Put effects here (on the option), not on the next narration.
                 {"id": "hub_end", "label": "Call it a day (end demo)",
@@ -111,6 +112,13 @@ STORY = {
             "id": "hub_training_say",
             "type": "narration",
             "text": "You stretch and run drills with your companion. Spirits high; muscles burning—good burn.",
+            "next": "hub_1"
+        },
+        {
+            "id": "hub_rest_say",
+            "type": "narration",
+            "effects": [ { "op": "restore_energy_full" } ],
+            "text": "You take a proper rest. Your energy is fully restored.",
             "next": "hub_1"
         },
         {


### PR DESCRIPTION
- Repo: restore_energy_full() and spend_energy() for SQL/Memory backends
- Narrative: support “restore_energy_full” and “spend_energy” ops
- Story: Oakhaven hub adds “Rest at the bunks (restore energy)”
- Web: player header shows name/energy/pet and refreshes after actions
- Docs: Phase 2 test steps included