### PR TITLE
feat(api,web): energy loop — training costs 1, rest refills to full

### DIFF
--- a/data/section_0/story.py
+++ b/data/section_0/story.py
@@ -112,6 +112,7 @@ STORY = {
             "id": "hub_training_say",
             "type": "narration",
             "text": "You stretch and run drills with your companion. Spirits high; muscles burning—good burn.",
+            "effects": [{"op": "spend_energy", "amount": 1}],
             "next": "hub_1"
         },
         {


### PR DESCRIPTION
- Repo:
  - Add energy helpers to both repos: restore_energy_full, add_energy, spend_energy.
  - Normalize DB columns to energy / max_energy and main_pet_species (drop current_energy/main_pet_id usage).
  - Fix MemoryRepository.set_main_pet_by_species to set main_pet_species.
- Narrative:
  - Training yard now consumes 1 energy (spend_energy).
  - Rest step refills energy to max (restore_energy_full).
- Web:
  - Player header shows Energy x/y and main pet species.
  - Reset tutorial button calls /session/reset and refreshes player state.

Notes:
- If your DB had legacy names, we’re using energy / max_energy consistently now.
- CORS/env as previously configured.