### PR TITLE
feat: Whisperwood Grove, Remnants, step-by-step travel, defeat respawn

### DIFF
--- a/cogs/adventure.py
+++ b/cogs/adventure.py
@@ -13,10 +13,10 @@ from data.pets import PET_DATABASE, ENCOUNTER_TABLES
 from data.items import ITEMS
 from data.abilities import SHARED_PASSIVES_BY_TYPE
 from data.explore_events import get_zone_events, get_zone_loot
-from utils.helpers import get_status_bar, get_town_embed, check_quest_progress, get_notification
+from utils.helpers import get_status_bar, get_town_embed, get_remnant_embed, check_quest_progress, get_notification, is_remnant
 from core.battle_engine import BattleState  # <-- Key Change: Importing from core
 from .resources import ACTION_COSTS
-from .views.towns import TownView, WildsView
+from .views.towns import TownView, WildsView, RemnantView
 from .views.combat import CombatView
 
 
@@ -41,6 +41,10 @@ class Adventure(commands.Cog):
         if location_data.get('is_wilds', False):
             view = WildsView(self.bot, interaction, location_id)
             embed = view.embed
+        elif is_remnant(location_id):
+            embed = await get_remnant_embed(self.bot, interaction.user.id, location_id)
+            view = RemnantView(self.bot, interaction, location_id)
+            await view.initial_setup()
         else:
             embed = await get_town_embed(self.bot, interaction.user.id, location_id)
             view = TownView(self.bot, interaction, location_id)

--- a/cogs/resources.py
+++ b/cogs/resources.py
@@ -5,7 +5,7 @@ from discord.ext import commands
 # This dictionary defines the costs for each action.
 ACTION_COSTS = {
     "explore": {"energy": 2, "hunger": 1},
-    "travel": {"energy": 3, "hunger": 2},
+    "travel": {"energy": 10, "hunger": 2},
     "battle": {"energy": 5, "hunger": 3}
 }
 

--- a/cogs/views/towns.py
+++ b/cogs/views/towns.py
@@ -11,8 +11,13 @@ from .shop import ShopView
 # --- REFACTORED IMPORTS ---
 from data.items import ITEMS
 from data.towns import TOWNS
+from data.remnants import REMNANTS
 from data.dialogues import DIALOGUES
-from utils.helpers import get_status_bar, get_town_embed, check_quest_progress, get_notification, format_log_block
+from utils.helpers import (
+    get_status_bar, get_town_embed, get_remnant_embed,
+    check_quest_progress, get_notification, format_log_block,
+    get_location_data, get_connections, is_remnant,
+)
 
 
 class WildsView(discord.ui.View):
@@ -76,7 +81,7 @@ class WildsView(discord.ui.View):
         if not town_connection_id:
             return await interaction.edit_original_response(content="Error: Cannot find path back to town.", view=None, embed=None)
 
-        await db_cog.update_player(self.user_id, current_location=town_connection_id)
+        await db_cog.update_player(self.user_id, current_location=town_connection_id, last_town_id=town_connection_id)
         new_embed = await get_town_embed(self.bot, self.user_id, town_connection_id)
         new_view = TownView(self.bot, self.original_interaction, town_connection_id)
         await new_view.initial_setup()
@@ -109,7 +114,22 @@ class TravelView(discord.ui.View):
         self.connections = connections
         self.main_message_to_edit = main_message_to_edit
         self.message = None  # set by travel_callback after send
-        options = [discord.SelectOption(label=name, value=loc_id) for loc_id, name in connections.items()]
+        travel_energy = ACTION_COSTS.get("travel", {}).get("energy", 3)
+        options = []
+        for loc_id, name in connections.items():
+            loc_data = get_location_data(loc_id)
+            gloom = loc_data.get('gloom_level', 0)
+            loc_type = "Town" if loc_id in TOWNS else "Remnant"
+            desc_parts = [f"⚡ {travel_energy} energy"]
+            if gloom > 0:
+                desc_parts.append(f"Gloom: {gloom}%")
+            desc_parts.append(loc_type)
+            options.append(discord.SelectOption(
+                label=name,
+                value=loc_id,
+                description=" · ".join(desc_parts),
+                emoji=loc_data.get('emoji'),
+            ))
         select = discord.ui.Select(placeholder="Choose a destination...", options=options)
         select.callback = self.select_callback
         self.add_item(select)
@@ -118,20 +138,34 @@ class TravelView(discord.ui.View):
         await interaction.response.defer()
         destination_id = interaction.data['values'][0]
         db_cog = self.bot.get_cog('Database')
-        await db_cog.update_player(self.original_interaction.user.id, current_location=destination_id)
-        destination_data = TOWNS.get(destination_id, {})
+        user_id = self.original_interaction.user.id
 
-        new_view = None
-        if destination_data.get('is_wilds', False):
-            new_embed = discord.Embed(title=f"Location: {destination_data.get('name')}",
-                                      description=destination_data.get('description'), color=discord.Color.dark_green())
+        # Track last town so defeat can respawn the player there
+        update_kwargs = {"current_location": destination_id}
+        if destination_id in TOWNS and not get_location_data(destination_id).get('is_wilds'):
+            update_kwargs["last_town_id"] = destination_id
+
+        await db_cog.update_player(user_id, **update_kwargs)
+        destination_data = get_location_data(destination_id)
+
+        # Determine what kind of location we're arriving at
+        if destination_data.get('is_wilds'):
+            new_embed = discord.Embed(
+                title=f"Location: {destination_data.get('name')}",
+                description=destination_data.get('description'),
+                color=discord.Color.dark_green()
+            )
             new_view = WildsView(self.bot, self.original_interaction, destination_id)
+        elif is_remnant(destination_id):
+            new_embed = await get_remnant_embed(self.bot, user_id, destination_id)
+            new_view = RemnantView(self.bot, self.original_interaction, destination_id)
+            await new_view.initial_setup()
         else:
-            new_embed = await get_town_embed(self.bot, self.original_interaction.user.id, destination_id)
+            new_embed = await get_town_embed(self.bot, user_id, destination_id)
             new_view = TownView(self.bot, self.original_interaction, destination_id)
             await new_view.initial_setup()
 
-        player_and_pet_data = await db_cog.get_player_and_pet_data(self.original_interaction.user.id)
+        player_and_pet_data = await db_cog.get_player_and_pet_data(user_id)
         if player_and_pet_data:
             status_bar = get_status_bar(player_and_pet_data['player_data'], player_and_pet_data['main_pet_data'])
             new_embed.set_footer(text=status_bar)
@@ -140,10 +174,9 @@ class TravelView(discord.ui.View):
         new_view.message = self.main_message_to_edit
         await interaction.delete_original_response()
 
-        # Check if arriving here completes a travel assignment
+        # Check if arriving here completes a travel quest objective
         quest_updates = await check_quest_progress(
-            self.bot, self.original_interaction.user.id,
-            "travel", {"location_id": destination_id},
+            self.bot, user_id, "travel", {"location_id": destination_id},
             channel=self.original_interaction.channel
         )
         if quest_updates:
@@ -168,6 +201,175 @@ class TravelView(discord.ui.View):
                 pass
 
 
+class RemnantView(discord.ui.View):
+    """View for Remnant road stops. Simpler than TownView — no sub-locations."""
+
+    def __init__(self, bot, parent_interaction, remnant_id):
+        super().__init__(timeout=180)
+        self.bot = bot
+        self.parent_interaction = parent_interaction
+        self.user_id = parent_interaction.user.id
+        self.message = None
+        self.remnant_id = remnant_id
+
+    async def initial_setup(self):
+        db_cog = self.bot.get_cog('Database')
+        player_data = await db_cog.get_player(self.user_id)
+        time_of_day = player_data.get('day_of_cycle', 'morning') if player_data else 'morning'
+        remnant = REMNANTS.get(self.remnant_id, {})
+        services = remnant.get('services', {})
+
+        _DAY_PHASES   = {'morning', 'noon'}
+        _NIGHT_PHASES = {'evening', 'night'}
+
+        # Explore button
+        if 'explore_zone' in services:
+            explore_btn = discord.ui.Button(label="Explore Area", style=discord.ButtonStyle.green, emoji="🌲")
+            explore_btn.callback = self.explore_callback
+            self.add_item(explore_btn)
+
+        # NPC talk buttons
+        for npc_id, npc_data in remnant.get('npcs', {}).items():
+            avail = npc_data.get('availability', 'all')
+            if avail == 'all':
+                available = True
+            elif avail == 'day':
+                available = time_of_day in _DAY_PHASES
+            elif avail == 'night':
+                available = time_of_day in _NIGHT_PHASES
+            else:
+                available = avail == time_of_day
+            btn = discord.ui.Button(
+                label=f"Talk to {npc_data['name']}",
+                style=discord.ButtonStyle.secondary,
+                disabled=not available
+            )
+            btn.callback = self._make_talk_callback(npc_id, npc_data)
+            self.add_item(btn)
+
+        # Travel button
+        travel_btn = discord.ui.Button(label="Travel", style=discord.ButtonStyle.blurple, emoji="🗺️")
+        travel_btn.callback = self.travel_callback
+        self.add_item(travel_btn)
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id != self.user_id:
+            await interaction.response.send_message("This is not your menu!", ephemeral=True)
+            return False
+        return True
+
+    def _make_talk_callback(self, npc_id, npc_data):
+        async def callback(interaction: discord.Interaction):
+            await interaction.response.defer()
+            db_cog = self.bot.get_cog('Database')
+            player_data = await db_cog.get_player(self.user_id)
+            time_of_day = player_data.get('day_of_cycle', 'morning') if player_data else 'morning'
+            dialogue = npc_data.get('dialogue', {})
+            text = (dialogue.get(time_of_day)
+                    or dialogue.get('default')
+                    or "...")
+            embed = discord.Embed(
+                title=f"{npc_data.get('emoji', '💬')} {npc_data['name']}",
+                description=f"*\"{text}\"*",
+                color=discord.Color.dark_teal()
+            )
+            await interaction.followup.send(embed=embed, ephemeral=True)
+        return callback
+
+    async def explore_callback(self, interaction: discord.Interaction):
+        remnant = REMNANTS.get(self.remnant_id, {})
+        zone_id = remnant.get('services', {}).get('explore_zone', self.remnant_id)
+        adventure_cog = self.bot.get_cog('Adventure')
+        if adventure_cog:
+            await adventure_cog.explore(interaction, zone_id, view_context=self)
+
+    async def travel_callback(self, interaction: discord.Interaction):
+        await interaction.response.defer(ephemeral=True)
+        db_cog = self.bot.get_cog('Database')
+        player_data = await db_cog.get_player(self.user_id)
+        travel_cost = ACTION_COSTS.get("travel", {}).get("energy", 3)
+        if player_data['energy'] < travel_cost:
+            return await interaction.followup.send(
+                f"You need at least {travel_cost} energy to travel.", ephemeral=True
+            )
+        remnant = REMNANTS.get(self.remnant_id, {})
+        connections = remnant.get('connections', {})
+        if not connections:
+            return await interaction.followup.send("There's nowhere to go from here.", ephemeral=True)
+        travel_view = TravelView(self.bot, self.parent_interaction, connections, self.message)
+        travel_msg = await interaction.followup.send("Where would you like to travel?", view=travel_view, ephemeral=True)
+        travel_view.message = travel_msg
+
+    async def update_with_activity_log(self, log_list: list[str]):
+        """
+        Called after a battle resolves. If the player was defeated and is at a Remnant,
+        respawn them at their last town. Otherwise refresh the Remnant embed in place.
+        """
+        db_cog = self.bot.get_cog('Database')
+        player_data = await db_cog.get_player(self.user_id)
+
+        # Defeat respawn — send the player back to their last town
+        is_defeat = any("Defeated" in entry for entry in log_list)
+        if is_defeat:
+            last_town = player_data.get('last_town_id') or 'oakhavenOutpost'
+            await db_cog.update_player(self.user_id, current_location=last_town)
+
+            new_embed = await get_town_embed(self.bot, self.user_id, last_town)
+            new_view = TownView(self.bot, self.parent_interaction, last_town)
+            await new_view.initial_setup()
+
+            # Append retreat note to the log
+            from data.towns import TOWNS as _TOWNS
+            town_name = _TOWNS.get(last_town, {}).get('name', 'town')
+            log_list.append(f"🏠 **Retreated**\n*You were forced back to {town_name}.*")
+
+            player_and_pet_data = await db_cog.get_player_and_pet_data(self.user_id)
+            if player_and_pet_data:
+                from utils.helpers import get_status_bar as _gsb
+                new_embed.set_footer(text=_gsb(player_and_pet_data['player_data'], player_and_pet_data['main_pet_data']))
+
+            # Add battle outcome as a field on the town embed
+            from utils.helpers import format_log_block as _flb
+            new_embed.add_field(name="Battle Result", value=_flb(log_list), inline=False)
+
+            try:
+                await self.message.edit(embed=new_embed, view=new_view)
+                new_view.message = self.message
+            except (discord.NotFound, discord.HTTPException):
+                try:
+                    msg = await self.parent_interaction.followup.send(embed=new_embed, view=new_view, ephemeral=True)
+                    new_view.message = msg
+                except Exception:
+                    pass
+            return
+
+        # Normal case — battle won, stay at the Remnant
+        remnant = REMNANTS.get(self.remnant_id, {})
+        new_embed = await get_remnant_embed(self.bot, self.user_id, self.remnant_id)
+        from utils.helpers import format_log_block as _flb, get_status_bar as _gsb
+        new_embed.add_field(name="Battle Result", value=_flb(log_list), inline=False)
+
+        player_and_pet_data = await db_cog.get_player_and_pet_data(self.user_id)
+        if player_and_pet_data:
+            new_embed.set_footer(text=_gsb(player_and_pet_data['player_data'], player_and_pet_data['main_pet_data']))
+
+        try:
+            await self.message.edit(embed=new_embed, view=self)
+        except (discord.NotFound, discord.HTTPException):
+            try:
+                msg = await self.parent_interaction.followup.send(embed=new_embed, view=self, ephemeral=True)
+                self.message = msg
+            except Exception:
+                pass
+
+    async def on_timeout(self):
+        if self.message:
+            try:
+                await self.message.edit(view=None)
+            except (discord.NotFound, discord.HTTPException):
+                pass
+
+
 class TownView(discord.ui.View):
     def __init__(self, bot, parent_interaction, town_id):
         super().__init__(timeout=180)
@@ -183,6 +385,20 @@ class TownView(discord.ui.View):
         self.build_ui()
 
     # --- NEW HELPER TO BUILD THE SUB-LOCATION EMBED ---
+    _DAY_PHASES   = {'morning', 'noon'}
+    _NIGHT_PHASES = {'evening', 'night'}
+
+    def _is_location_open(self, location_info: dict, time_of_day: str) -> bool:
+        """Returns True if the location is open at the given time of day."""
+        avail = location_info.get('availability', 'all')
+        if avail == 'all':
+            return True
+        if avail == 'day':
+            return time_of_day in self._DAY_PHASES
+        if avail == 'night':
+            return time_of_day in self._NIGHT_PHASES
+        return avail == time_of_day  # exact phase match (e.g. 'morning' only)
+
     async def _build_sublocation_embed(self, location_info, log_list: list[str] = None):
         """Builds a standard embed for a sub-location, including hazards and logs."""
 
@@ -284,10 +500,6 @@ class TownView(discord.ui.View):
                 self.add_item(discord.ui.Button(label="Shop", style=discord.ButtonStyle.blurple, emoji="🛒"))
                 self.children[-1].callback = self.shop_callback
 
-            # Map 4 phases to broad day/night groups for availability checks
-            _DAY_PHASES   = {'morning', 'noon'}
-            _NIGHT_PHASES = {'evening', 'night'}
-
             for npc_id, npc_data in location_info.get('npcs', {}).items():
                 avail = npc_data.get('availability', 'all')
                 if avail == 'all':
@@ -309,11 +521,14 @@ class TownView(discord.ui.View):
         else:
             town_info = TOWNS.get(self.town_id, {})
             locations = town_info.get('locations', {})
-            location_options = [
-                discord.SelectOption(label=data['name'], value=loc_id, description=data.get('menu_description'),
-                                     emoji=data.get('emoji'))
-                for loc_id, data in locations.items()
-            ]
+            location_options = []
+            for loc_id, data in locations.items():
+                is_open = self._is_location_open(data, time_of_day)
+                label = data['name'] if is_open else f"🔒 {data['name']}"
+                location_options.append(
+                    discord.SelectOption(label=label, value=loc_id,
+                                         description=data.get('menu_description'), emoji=data.get('emoji'))
+                )
             if location_options:
                 select = discord.ui.Select(placeholder="Explore locations in town...", options=location_options)
                 select.callback = self.select_location_callback
@@ -388,6 +603,34 @@ class TownView(discord.ui.View):
 
         location_info = TOWNS.get(self.town_id, {}).get('locations', {}).get(self.current_sub_location_id, {})
 
+        # Check if location is open — if not, show a closed embed with no action buttons
+        db_cog = self.bot.get_cog('Database')
+        player_data = await db_cog.get_player(self.user_id)
+        time_of_day = player_data.get('day_of_cycle', 'morning') if player_data else 'morning'
+
+        if not self._is_location_open(location_info, time_of_day):
+            # Pick the closed description (night or day fallback)
+            closed_desc = (
+                location_info.get(f'description_{time_of_day}')
+                or location_info.get('description_night')
+                or location_info.get('description_day')
+                or location_info.get('description')
+                or "This location is currently closed."
+            )
+            closed_embed = discord.Embed(
+                title=f"🔒 {location_info.get('name', 'Location')}",
+                description=closed_desc,
+                color=discord.Color.dark_gray()
+            )
+            closed_embed.set_footer(text="Come back later.")
+            # Only show Back button
+            self.clear_items()
+            back_btn = discord.ui.Button(label="Back to Town Hub", style=discord.ButtonStyle.grey, emoji="↩️")
+            back_btn.callback = self.back_to_town_callback
+            self.add_item(back_btn)
+            await interaction.edit_original_response(embed=closed_embed, view=self)
+            return
+
         # Use the new helper to build the initial embed
         new_embed = await self._build_sublocation_embed(location_info)
 
@@ -413,15 +656,17 @@ class TownView(discord.ui.View):
                 ephemeral=True
             )
 
-        town_data = TOWNS.get(self.town_id, {})
+        town_data = get_location_data(self.town_id)
         all_connections = town_data.get('connections', {})
         connection_reqs = town_data.get('connection_requirements', {})
         player_flags = player_data.get('flags', set())
 
-        # Filter out destinations the player hasn't unlocked yet
+        # Filter out wilds zones (shown as Explore Wilds button, not in travel dropdown)
+        # and destinations the player hasn't unlocked yet
         connections = {
             loc_id: name for loc_id, name in all_connections.items()
-            if loc_id not in connection_reqs or connection_reqs[loc_id] in player_flags
+            if not get_location_data(loc_id).get('is_wilds')
+            and (loc_id not in connection_reqs or connection_reqs[loc_id] in player_flags)
         }
 
         if not connections:

--- a/data/explore_events.py
+++ b/data/explore_events.py
@@ -131,9 +131,9 @@ EXPLORE_EVENTS = {
     ],
 
     # ─────────────────────────────────────────────
-    # Oakhaven Wilds
+    # Outpost Wilds
     # ─────────────────────────────────────────────
-    "oakhavenWilds": [
+    "outpostWilds": [
 
         # --- Flavor ---
         {
@@ -262,7 +262,7 @@ ZONE_LOOT_TABLES = {
         ("moss_balm",        2),
         ("tether_orb",       1),
     ],
-    "oakhavenWilds": [
+    "outpostWilds": [
         ("sun_kissed_berries", 4),
         ("trail_morsels",      2),
         ("moss_balm",          1),

--- a/data/pets.py
+++ b/data/pets.py
@@ -519,7 +519,7 @@ def get_pet_data(species: str) -> dict:
 
 ENCOUNTER_TABLES = {
 
-    "oakhavenWilds": {
+    "outpostWilds": {
         "day": ["Pineling"],
         "night": ["Pineling"]
     },

--- a/data/remnants.py
+++ b/data/remnants.py
@@ -1,0 +1,283 @@
+# data/remnants.py
+# Remnants — Points of Interest found between towns.
+#
+# Remnants are optional locations discovered while traveling between towns.
+# They are not full towns — no inn, no shops — but they can have:
+#   - NPCs (quest givers, lore, merchants)
+#   - Explore zones (unique encounters)
+#   - Quest hooks
+#   - Unique items or drops
+#
+# "between" defines which two towns flank this remnant on the road.
+# "availability" can restrict when the remnant is accessible (day/night/all).
+# "gloom_level" — if set, all battles here start with this Gloom % preloaded.
+
+REMNANTS = {
+
+    # =========================================================================
+    # ROAD: Oakhaven Outpost ↔ Whisperwood Grove
+    # =========================================================================
+
+    "weeping_chasm": {
+        "id": "weeping_chasm",
+        "name": "The Weeping Chasm",
+        "emoji": "🕳️",
+        "between": ["oakhavenOutpost", "whisperwoodGrove"],
+        "connections": {
+            "oakhavenOutpost": "Oakhaven Outpost",
+            "mirefields": "Mirefields",
+        },
+        "availability": "all",
+        "gloom_level": 25,
+        "description_day": (
+            "A jagged tear in the earth stretches across the road, as if the land itself "
+            "was ripped open long ago. A faint, cold mist rises from below, carrying with it "
+            "the distant sound of something — breathing. Guild records mark this as the site "
+            "where The Gloom first breached the surface world."
+        ),
+        "description_night": (
+            "At night, the Chasm seems to exhale — a rhythmic pulse of cold air that makes "
+            "the trees lean away. The mist thickens into something almost visible, and the "
+            "darkness below feels aware of you."
+        ),
+        "lore": (
+            "This is where it began. Centuries ago, a crack formed in the bedrock and the "
+            "first tendrils of The Gloom seeped upward. The Guild sealed what they could, "
+            "but the scar never healed."
+        ),
+        "npcs": {
+            "chasm_warden": {
+                "name": "Warden Orin",
+                "role": "Guild Warden",
+                "emoji": "🛡️",
+                "availability": "day",
+                "dialogue": {
+                    "default": (
+                        "This is as close as most people get. The Chasm draws Gloom-Touched "
+                        "creatures — they're drawn to the source. I keep watch so travelers "
+                        "can pass safely. Mostly."
+                    ),
+                    "lore_prompt": (
+                        "The records say The Gloom first surfaced here. I believe it. "
+                        "Some nights I can feel it thinking."
+                    ),
+                }
+            }
+        },
+        "services": {
+            "explore_zone": "weeping_chasm",
+        },
+    },
+
+    "mirefields": {
+        "id": "mirefields",
+        "name": "The Mirefields",
+        "emoji": "🌫️",
+        "between": ["oakhavenOutpost", "whisperwoodGrove"],
+        "connections": {
+            "weeping_chasm": "Weeping Chasm",
+            "whisperwoodGrove": "Whisperwood Grove",
+        },
+        "availability": "all",
+        "gloom_level": 8,
+        "description_day": (
+            "A stretch of dense, boggy terrain where the road becomes little more than a "
+            "muddy suggestion. Twisted undergrowth crowds the path and the air smells of "
+            "damp earth and rot. The creatures here are territorial and aggressive — not "
+            "Gloom-touched, just mean. The ruins of an old crossroads camp can be spotted "
+            "through the fog, long since reclaimed by the mire."
+        ),
+        "description_night": (
+            "The fog thickens after dark, swallowing what little visibility remained. "
+            "Sounds carry strangely through the mire — snapping branches, low growls, "
+            "the occasional splash of something moving through the water. "
+            "Not the place to stop and rest."
+        ),
+        "lore": (
+            "Once a busy waystation for traders moving between Oakhaven and the forests "
+            "beyond. When the road fell out of use, the mire moved in. "
+            "A few stubborn souls still pass through — and a few still live here."
+        ),
+        "npcs": {
+            "sable": {
+                "name": "Sable",
+                "role": "Bog Trapper",
+                "emoji": "🪤",
+                "availability": "all",
+                "dialogue": {
+                    "default": (
+                        "You lost? Most people don't come through here by choice. "
+                        "I've got supplies if you need them — nothing fancy, but it'll keep you alive."
+                    ),
+                    "night": (
+                        "You're braver than most, traveling through here at night. "
+                        "Or dumber. Hard to tell. Watch your step — the mire shifts after dark."
+                    ),
+                    "sell": "Take what you need and move on. I don't do small talk.",
+                }
+            }
+        },
+        "services": {
+            "explore_zone": "mirefields",
+            "shop": True,
+            "shop_items": ["moss_balm", "trail_morsels", "tether_orb"],
+        },
+    },
+
+    # =========================================================================
+    # ROAD: Whisperwood Grove ↔ Sunstone Oasis
+    # =========================================================================
+
+    "glade_of_whispers": {
+        "id": "glade_of_whispers",
+        "name": "The Glade of Whispers",
+        "emoji": "✨",
+        "between": ["whisperwoodGrove", "sunstoneOasis"],
+        "connections": {
+            "whisperwoodGrove": "Whisperwood Grove",
+            "sunstoneOasis": "Sunstone Oasis",
+        },
+        "availability": "all",
+        "gloom_level": 0,
+        "description_day": (
+            "A small, perfectly circular glade where sunlight filters through a natural "
+            "opening in the canopy. The air hums faintly — not with danger, but with something "
+            "older and calmer. Flowers here bloom year-round, and the grass is always soft. "
+            "Adventurers often stop to rest."
+        ),
+        "description_night": (
+            "At night the glade is lit by the soft glow of Moonpetal flowers that only "
+            "bloom here after dark. The humming grows quieter but doesn't stop. "
+            "It feels like the forest is holding its breath — in a good way."
+        ),
+        "lore": (
+            "One of the few places in Aethelgard where the Gloom has never taken hold. "
+            "Scholars believe a Great Spirit once rested here, leaving a lasting impression "
+            "on the land. Pets recover faster in this glade."
+        ),
+        "npcs": {},
+        "services": {
+            "rest": {
+                "type": "glade",
+                "cost": 0,
+                "energy_restore_percent": 25,
+                "health_restore_percent": 50,  # Natural healing, free
+            }
+        },
+    },
+
+    # =========================================================================
+    # STUBS — Further roads (fill in when those towns are built)
+    # =========================================================================
+
+    "obsidian_monoliths": {
+        "id": "obsidian_monoliths",
+        "name": "The Obsidian Monoliths",
+        "emoji": "🗿",
+        "between": ["sunstoneOasis", "ironforge"],
+        "availability": "all",
+        "description_day": "Strange formations of jet-black stone rise from the desert floor, humming with a faint magnetic energy. Compasses are useless here.",
+        "npcs": {},
+        "services": {},
+    },
+
+    "shifting_dunes": {
+        "id": "shifting_dunes",
+        "name": "The Shifting Dunes",
+        "emoji": "🏜️",
+        "between": ["sunstoneOasis", "aethelgardsRest"],
+        "availability": "all",
+        "description_day": "A treacherous desert region where the sands move on their own, erasing paths overnight. More than one caravan has been lost here.",
+        "npcs": {},
+        "services": {},
+    },
+
+    "lost_guild_hall": {
+        "id": "lost_guild_hall",
+        "name": "The Lost Guild Hall",
+        "emoji": "🏚️",
+        "between": ["frostfallPeak", "blackwaterMarsh"],
+        "availability": "all",
+        "description_day": "An ancient, overgrown ruin of what was once a proud Guild Hall. Ivy has reclaimed the walls, and the records inside — if any survived — could be invaluable.",
+        "npcs": {},
+        "services": {},
+    },
+
+    "sunken_ship_graveyard": {
+        "id": "sunken_ship_graveyard",
+        "name": "The Sunken Ship Graveyard",
+        "emoji": "⚓",
+        "between": ["aethelgardsRest", "skylightSpire"],
+        "availability": "all",
+        "description_day": "A treacherous stretch of reef and rusted shipwrecks, half-submerged and groaning in the current. Salvagers come here, but not all of them leave.",
+        "npcs": {},
+        "services": {},
+    },
+
+    "wyrmwood_forest": {
+        "id": "wyrmwood_forest",
+        "name": "The Wyrmwood Forest",
+        "emoji": "🌑",
+        "between": ["blackwaterMarsh", "ironforge"],
+        "availability": "all",
+        "description_day": "A dark, twisted forest where the trees grow in unnatural spirals and the canopy blocks all sunlight. The Gloom runs deep here.",
+        "npcs": {},
+        "services": {},
+    },
+
+    "cloudspire_outpost": {
+        "id": "cloudspire_outpost",
+        "name": "The Cloudspire Outpost",
+        "emoji": "☁️",
+        "between": ["skylightSpire", "silvermoonGlade"],
+        "availability": "all",
+        "description_day": "A small floating platform suspended between two peaks by ancient chain-work. The view is breathtaking. The wind is brutal.",
+        "npcs": {},
+        "services": {},
+    },
+
+    "scholars_retreat": {
+        "id": "scholars_retreat",
+        "name": "The Scholar's Retreat",
+        "emoji": "📚",
+        "between": ["silvermoonGlade", "sunkenCity"],
+        "availability": "day",
+        "description_day": "A secluded library hidden between two cliff faces, accessible only by a narrow rope bridge. The collection inside spans centuries of Aethelgard's history.",
+        "npcs": {},
+        "services": {},
+    },
+
+    "chasm_of_whispers": {
+        "id": "chasm_of_whispers",
+        "name": "The Chasm of Whispers",
+        "emoji": "🌀",
+        "between": ["ironforge", "skylightSpire"],
+        "availability": "all",
+        "description_day": "A deep, winding canyon whose walls amplify sound in strange ways. Voices echo here that have no source. Travelers move through quickly.",
+        "npcs": {},
+        "services": {},
+    },
+
+    "forgotten_grove": {
+        "id": "forgotten_grove",
+        "name": "The Forgotten Grove",
+        "emoji": "🌸",
+        "between": ["blackwaterMarsh", "ironforge"],  # hidden within Wyrmwood
+        "availability": "all",
+        "description_day": "A beautiful grove hidden within the Wyrmwood Forest that has miraculously resisted the Gloom. The contrast with the surrounding darkness is striking.",
+        "npcs": {},
+        "services": {},
+    },
+
+    "serpents_coil": {
+        "id": "serpents_coil",
+        "name": "The Serpent's Coil",
+        "emoji": "🐍",
+        "between": ["sunkenCity", "dragonsTooth"],
+        "availability": "all",
+        "description_day": "A treacherous winding path through ancient ruins that corkscrews down into a valley. The stonework is unlike anything built by current civilization.",
+        "npcs": {},
+        "services": {},
+    },
+
+}

--- a/data/towns.py
+++ b/data/towns.py
@@ -16,14 +16,13 @@ TOWNS = {
         "description_day": "The scent of fresh-cut pine fills the air. A single, ancient oak tree stands as a silent sentinel over this humble collection of sturdy log cabins.",
 
         # --- THIS IS FOR THE "TRAVEL" BUTTON ---
-        # Oakhaven Wilds is NOT here — it's accessed via Explore Wilds, not Travel.
+        # outpostWilds accessed via Explore Wilds button, not Travel.
+        # Step-by-step travel: Oakhaven → Weeping Chasm → Mirefields → Whisperwood
         "connections": {
-            "whisperwoodGrove": "Whisperwood Grove"
+            "weeping_chasm": "Weeping Chasm",
         },
-        # Optional flag required per destination. If set, the destination is hidden
-        # from the travel menu until the player has that flag.
         "connection_requirements": {
-            "whisperwoodGrove": "quest_a_guildsmans_first_steps_completed"
+            "weeping_chasm": "quest_a_guildsmans_first_steps_completed"
         },
 
         # --- THIS IS FOR THE DROPDOWN MENU ---
@@ -126,18 +125,22 @@ TOWNS = {
             }
         }
     },
-                # --- MOVED TO HERE ---
-                "oakhavenWilds": {
-                    "id": "oakhavenWilds",
-                    "name": "Oakhaven Wilds",
-                    "is_wilds": True,
-                    "description": "The rugged wilderness just outside the safety of the outpost.",
-                    "connections": {
-                        "oakhavenOutpost": "Oakhaven Outpost"
-                    },
-                    "explore_zone": "oakhavenWilds"
-                },
+    # Outpost Wilds — accessed via Explore Wilds button from Oakhaven Outpost
+    "outpostWilds": {
+        "id": "outpostWilds",
+        "name": "Outpost Wilds",
+        "is_wilds": True,
+        "description": "The rugged wilderness just outside the safety of the outpost. Tar fumes drift on the wind, and the underbrush stirs with unseen creatures.",
+        "connections": {
+            "oakhavenOutpost": "Oakhaven Outpost"
+        },
+        "explore_zone": "outpostWilds"
+    },
 
+    # ---------------------------------------------------------------------------
+    # TOWN 2 — Whisperwood Grove
+    # First real town. Home of the Verdant Crest and Elder Vexia.
+    # ---------------------------------------------------------------------------
     "whisperwoodGrove": {
         "id": "whisperwoodGrove",
         "name": "Whisperwood Grove",
@@ -148,31 +151,90 @@ TOWNS = {
         "description_night": "Under the soft glow of the moon, the forest takes on a mystical quality. Lumina-moths float gently through the air, casting a soft light on the winding paths.",
         # Legacy fallback
         "description_day": "A tranquil and ancient forest where colossal trees reach for the sky. The town is built into the trees themselves, with winding rope bridges connecting cozy, treetop homes.",
+
+        # Travel connections — Whisperwood Wilds accessed via Explore Wilds button, not Travel
+        # Step-by-step travel: Whisperwood ← Mirefields ← Weeping Chasm ← Oakhaven
         "connections": {
-            "whisperwoodWilds": "Whisperwood Wilds",
-            "oakhavenOutpost": "Oakhaven Outpost"  # Travel back to the outpost itself
+            "mirefields": "Mirefields",
+            "whisperwoodWilds": "Whisperwood Wilds",  # is_wilds=True → renders as Explore Wilds button
         },
-        "prerequisite": None,
+
         "locations": {
-            "guild_hall": {
-                "name": "The Verdant Spire Guild Hall",
-                "availability": "day",
-                "description": "The center of Guild operations in Whisperwood Grove. Elder Vexia can often be found here, her wisdom as ancient as the trees.",
+            # ------------------------------------------------------------------
+            # 1. The Leaf-Lit Lodge — rest & pet healing, Arboreal the Treant
+            # ------------------------------------------------------------------
+            "leaf_lit_lodge": {
+                "name": "The Leaf-Lit Lodge",
+                "emoji": "🌳",
+                "menu_description": "A healing lodge tended by an ancient Treant. Restore your companions here.",
+                "availability": "all",
+                "description_day": "A large, welcoming lodge woven from living branches and glowing moss. Soft light emanates from within, and the gentle chirping of various forest creatures fills the air.",
+                "description_night": "Even in the dark, the lodge glows with a warm, bioluminescent light. The old Treant's lanterns never go out.",
+                "services": {
+                    "rest": {
+                        "type": "lodge",
+                        "cost": 0,
+                        "energy_restore_percent": 0,
+                        "health_restore_percent": 100,  # Free full pet HP restore
+                    }
+                },
                 "npcs": {
-                    "vexia": {
-                        "name": "Elder Vexia",
-                        "role": "Guild Master",
+                    "arboreal": {
+                        "name": "Arboreal",
+                        "role": "Treant Healer",
+                        "availability": "all",
                         "dialogue": {
-                            "day": "Welcome, young one. The whispers of the woods precede you. There is a sickness in this forest that needs a steady hand.",
-                            "quest_related": "A darkness gnaws at the heart of this grove. I need you to venture into the Whispering Thicket and find the source of the corruption."
+                            "default": "Welcome, young Adventurer. Let the forest's embrace soothe your companions. Rest here, for the path ahead demands strong bonds.",
+                            "after_heal": "May your roots grow deep, and your spirit soar.",
                         }
                     }
                 }
             },
-            "shop": {
-                "name": "The Root & Branch Emporium",
+
+            # ------------------------------------------------------------------
+            # 2. The Verdant Spire Guild Hall — Elder Vexia + Linden the Scribe
+            # ------------------------------------------------------------------
+            "verdant_spire": {
+                "name": "The Verdant Spire Guild Hall",
+                "emoji": "🏛️",
+                "menu_description": "The heart of Guild activity in the Grove. Speak with Elder Vexia.",
                 "availability": "day",
-                "description": "A cozy shop built into the base of a massive tree, run by a friendly Snail-folk named Slithers.",
+                "description_day": "A massive, hollowed-out ancient tree spiraling upwards with mossy walls and natural light. The air smells of old parchment and fresh leaves. Adventurers bustle throughout.",
+                "description_night": "The Guild Hall is dimly lit at night. Linden keeps a single candle burning at the Quest Board, but Elder Vexia has retired for the evening.",
+                "npcs": {
+                    "vexia": {
+                        "name": "Elder Vexia",
+                        "role": "Guild Master",
+                        "availability": "day",
+                        "dialogue": {
+                            "default": "The Grand Master's vision echoes even here, young one. The Verdant Crest is not won, but earned through understanding of nature's delicate balance.",
+                            "quest_whisperwoods_plea_active": "The Thicket grows darker by the day. Find the source of the corruption — the Heart of Decay. The forest is counting on you.",
+                            "quest_whisperwoods_plea_complete": "You've shown kindness and understanding. Now, let us see the strength of your bond. Face my companion — and prove yourself worthy.",
+                            "crest_earned": "The Verdant Crest rests with a worthy guardian, Adventurer. May its light guide you to the next challenge.",
+                        }
+                    },
+                    "linden": {
+                        "name": "Linden",
+                        "role": "Guild Scribe",
+                        "availability": "all",
+                        "dialogue": {
+                            "default": "Welcome to the Verdant Spire Guild Hall! Please check the Quest Board for available tasks. Remember, proper documentation is key!",
+                            "quest_complete": "Another quest completed? Excellent! Make sure you fill out the proper forms, Adventurer.",
+                        }
+                    }
+                }
+            },
+
+            # ------------------------------------------------------------------
+            # 3. The Root & Branch Emporium — Slithers the Snail-folk shopkeeper
+            # ------------------------------------------------------------------
+            "root_branch_emporium": {
+                "name": "The Root & Branch Emporium",
+                "emoji": "🛒",
+                "menu_description": "A quirky shop in the roots of the oldest tree. Pick up supplies and Capture Orbs.",
+                "availability": "day",
+                "description_day": "A quirky, charming shop built into the sprawling root system of the Grove's oldest tree. Shelves are laden with vials of dewdrop potions, bundles of strong vines, and various unusual forest finds.",
+                "description_night": "The shutters are closed. Slithers keeps early hours — come back when the sun warms the canopy.",
                 "items_for_sale": ["capture_orb", "moss_balm", "simple_sleeping_bag", "potion", "greater_potion"],
                 "services": {
                     "shop": True
@@ -181,58 +243,106 @@ TOWNS = {
                     "slithers": {
                         "name": "Slithers",
                         "role": "Shopkeeper",
-                        "dialogue": { "day": "Looking for supplies? You've come to the right... shell!" }
+                        "availability": "day",
+                        "dialogue": {
+                            "default": "Welcome, welcome, Adventurer! Need anything for the road? My wares are as fresh as the morning dew!",
+                            "capture_orb_hint": "Ah, a Capture Orb! Essential for befriending new forest friends!",
+                        }
                     }
                 }
             },
-            "inn": {
+
+            # ------------------------------------------------------------------
+            # 4. The Moonpetal Inn — full rest (costs coins)
+            # ------------------------------------------------------------------
+            "moonpetal_inn": {
                 "name": "The Moonpetal Inn",
+                "emoji": "🌙",
+                "menu_description": "A cozy inn glowing with moonpetal light. Sleep here to fully restore.",
                 "availability": "all",
-                "description": "A comfortable inn where you can get a full night's rest for a small fee.",
+                "description_day": "A cozy inn constructed from large, glowing moonpetal flowers and sturdy tree trunks. The air inside is filled with soothing, herbal scents.",
+                "description_night": "The inn glows warmly against the dark forest. A perfect place to rest weary bones and restore your companions.",
                 "services": {
                     "rest": {
                         "type": "inn",
-                        "cost": 10,
+                        "cost": 15,
                         "energy_restore_percent": 100,
-                        "health_restore_percent": 100
+                        "health_restore_percent": 100,
+                    }
+                },
+                "npcs": {
+                    "mira": {
+                        "name": "Mira",
+                        "role": "Innkeeper",
+                        "availability": "all",
+                        "dialogue": {
+                            "default": "Welcome to the Moonpetal Inn. Dust off your boots and rest a while — the forest will still be there in the morning.",
+                            "night": "You've come at the right hour. The inn is quietest now. The Lumina-moths are out, and the moonpetals are in full bloom. Quite a sight, if you're not too tired to look.",
+                            "after_rest": "Sleep well? The grove has a way of making even the most restless adventurers feel at home.",
+                        }
                     }
                 }
             },
-                "exploration": {
-                    "name": "The Whispering Thicket",
-                    "availability": "all",
-                    "description": "The deeper, untamed part of the forest. Be wary, as stronger creatures lurk here.",
-                    "services": {
-                        "explore_zone": "whisperwoodGrove"
+
+            # ------------------------------------------------------------------
+            # 5. The Whispering Thicket — primary explore zone, Fae Whisper NPC
+            # ------------------------------------------------------------------
+            "whispering_thicket": {
+                "name": "The Whispering Thicket",
+                "emoji": "🌿",
+                "menu_description": "Darker and wilder than the grove. Strange calls echo from within.",
+                "availability": "all",
+                "description_day": "A deeper, more overgrown section of the Whisperwood. The paths are less clear and the shadows are heavier. Strange calls echo from within.",
+                "description_night": "Under the moonlight, the Thicket feels genuinely threatening. The Gloom is stronger here, and the rustle of unseen creatures follows your every step.",
+                "services": {
+                    "explore_zone": "whisperwoodGrove",
+                    "gloom_level": 15,
+                },
+                "npcs": {
+                    "fae_whisper": {
+                        "name": "Fae Whisper",
+                        "role": "Pixie Sprite",
+                        "availability": "all",
+                        "dialogue": {
+                            "default": "*A tiny sprite flits past, leaving a trail of glittering dust.* Follow the lights, Adventurer... if you dare.",
+                        }
                     }
-                },
-                "whisperwoodWilds": { # --- NEW WILDS ZONE ---
-                    "id": "whisperwoodWilds",
-                    "name": "Whisperwood Wilds",
-                    "is_wilds": True,
-                    "description": "The dense, untamed forest surrounding the Grove.",
-                    "connections": {
-                        "whisperwoodGrove": "Whisperwood Grove"
-                    },
-                    "explore_zone": "whisperwoodGrove"
-                },
-            }
+                }
+            },
+        }
+    },
+
+    # Whisperwood Wilds — accessed via Explore Wilds button from Whisperwood Grove
+    "whisperwoodWilds": {
+        "id": "whisperwoodWilds",
+        "name": "Whisperwood Wilds",
+        "is_wilds": True,
+        "description": "The dense, untamed forest surrounding the Grove. Ancient trees loom overhead, their roots twisting across the path. The deeper you go, the heavier the air becomes.",
+        "connections": {
+            "whisperwoodGrove": "Whisperwood Grove"
         },
-            "sunstoneOasis": {
-                "id": "sunstoneOasis",
-                "name": "Sunstone Oasis",
-                "rank": "Journeyman",
-                "description_morning": "The desert air is crisp and cool before the sun fully rises. Merchants set up their stalls early, and the oasis glimmers with the promise of another day.",
-                "description_noon": "The heat is at its peak, driving most locals into the shade of canvas awnings. The oasis water shimmers brilliantly — a welcome refuge from the relentless sun.",
-                "description_evening": "As the sun sinks toward the dunes, the temperature drops rapidly and the oasis town truly comes alive. Lanterns are lit, music drifts through warm evening air.",
-                "description_night": "Under the cool desert night, the oasis comes alive with the glow of lanterns and the sound of music. The stars above are brilliant and clear.",
-                # Legacy fallback
-                "description_day": "A bustling town built around a life-giving oasis in the heart of a vast, sun-scorched desert. The heat is intense, but the spirit of the locals is resilient.",
-                "connections": ["whisperwoodGrove"], # Connection back to the grove
-                "prerequisite": None,
-                "locations": {
-                    # We can leave this empty for now
-                }
-            },
-    # ... (rest of the town data would go here)
-            }
+        "explore_zone": "whisperwoodGrove"
+    },
+
+    # ---------------------------------------------------------------------------
+    # TOWN 3 — Sunstone Oasis (stub, unlocked after Verdant Crest)
+    # ---------------------------------------------------------------------------
+    "sunstoneOasis": {
+        "id": "sunstoneOasis",
+        "name": "Sunstone Oasis",
+        "rank": "Journeyman",
+        "description_morning": "The desert air is crisp and cool before the sun fully rises. Merchants set up their stalls early, and the oasis glimmers with the promise of another day.",
+        "description_noon": "The heat is at its peak, driving most locals into the shade of canvas awnings. The oasis water shimmers brilliantly — a welcome refuge from the relentless sun.",
+        "description_evening": "As the sun sinks toward the dunes, the temperature drops rapidly and the oasis town truly comes alive. Lanterns are lit, music drifts through warm evening air.",
+        "description_night": "Under the cool desert night, the oasis comes alive with the glow of lanterns and the sound of music. The stars above are brilliant and clear.",
+        # Legacy fallback
+        "description_day": "A bustling town built around a life-giving oasis in the heart of a vast, sun-scorched desert. The heat is intense, but the spirit of the locals is resilient.",
+        "connections": {
+            "whisperwoodGrove": "Whisperwood Grove",
+        },
+        "locations": {
+            # Content coming in Town 3 update
+        }
+    },
+    # ... (remaining towns to be added)
+}

--- a/data/wandering_npcs.py
+++ b/data/wandering_npcs.py
@@ -1,0 +1,193 @@
+# data/wandering_npcs.py
+# Wandering NPCs that can appear on roads between towns.
+#
+# Structure:
+#   WANDERING_NPCS  — base pool, any NPC here can appear on any road
+#   PATH_ENCOUNTERS — per-road overrides: which NPCs appear and at what weight
+#
+# To add a road-exclusive NPC, define it in WANDERING_NPCS and only reference
+# it in the specific PATH_ENCOUNTERS entry you want it to appear in.
+
+WANDERING_NPCS = {
+
+    # -------------------------------------------------------------------------
+    # NON-COMBAT
+    # -------------------------------------------------------------------------
+
+    "traveling_merchant": {
+        "name": "Rowan",
+        "title": "Traveling Merchant",
+        "emoji": "🧳",
+        "type": "merchant",
+        "dialogue": {
+            "greeting": "Ah, a fellow traveler! I've got wares from all across Aethelgard. Take a look — you won't find these prices in any town.",
+            "farewell": "Safe roads, Adventurer. Watch your step out there.",
+        },
+        "shop_pool": ["moss_balm", "tether_orb", "trail_morsels", "simple_sleeping_bag"],
+        # Rotates a random subset of shop_pool each encounter
+        "shop_size": 3,
+    },
+
+    "guild_courier": {
+        "name": "Guild Courier",
+        "title": "Guild Courier",
+        "emoji": "📜",
+        "type": "quest_hint",
+        "dialogue": {
+            "greeting": "Courier business — no time to chat. But I did hear something at the last outpost you might want to know.",
+            "hint": "Word from the Guild: keep your eyes open on these roads. Things have been... unsettled lately.",
+            "farewell": "I've got a dozen more deliveries. Good luck out there.",
+        },
+    },
+
+    "field_medic": {
+        "name": "Field Medic",
+        "title": "Wandering Healer",
+        "emoji": "💊",
+        "type": "service",
+        "dialogue": {
+            "greeting": "You look like you've had a rough go of it. I can patch up your companion for a few coins — proper supplies cost money, after all.",
+            "after_heal": "There we go. Good as new. Try not to get them banged up too quickly.",
+            "farewell": "Take care of that companion. They're counting on you.",
+        },
+        "service": {
+            "type": "heal_pet",
+            "cost": 20,
+            "heal_percent": 50,
+        },
+    },
+
+    "lost_adventurer": {
+        "name": "Lost Adventurer",
+        "title": "Wayward Adventurer",
+        "emoji": "🗺️",
+        "type": "mini_quest",
+        "dialogue": {
+            "greeting": "Oh thank the Spirits — another person! I've been wandering these roads for hours. I think I took a wrong turn somewhere near the last landmark...",
+            "quest_offer": "If you could just point me toward the nearest town, I'd make it worth your while. I've got some supplies I can spare.",
+            "quest_complete": "You're a lifesaver. Literally. Here — take this. I was saving it, but I owe you.",
+            "farewell": "I'll be more careful next time. Probably.",
+        },
+        "reward_coins": 30,
+        "reward_items": ["moss_balm", "trail_morsels"],  # picks one randomly
+    },
+
+    "gloom_scout": {
+        "name": "Gloom Scout",
+        "title": "Guild Scout",
+        "emoji": "👁️",
+        "type": "intel",
+        "dialogue": {
+            "greeting": "Halt — Guild Scout. I've been tracking Gloom activity along this road. You'll want to hear this before you head further.",
+            "warning_low": "Gloom levels are low ahead. You're fine for now, but don't linger.",
+            "warning_high": "I'd be careful. The Gloom is thick further down this road. Make sure your companion is in good shape.",
+            "farewell": "Stay sharp. The Gloom doesn't announce itself.",
+        },
+    },
+
+    "drifter": {
+        "name": "The Drifter",
+        "title": "Mysterious Drifter",
+        "emoji": "🎲",
+        "type": "gamble",
+        "dialogue": {
+            "greeting": "You look like someone who appreciates a good gamble. I've got something in this pack — could be junk, could be treasure. Fifty coins says it's worth your while.",
+            "win": "Ha! Lady luck smiles on you today, Adventurer.",
+            "lose": "Better luck next time. That's the way of things.",
+            "farewell": "The road gives and the road takes. See you around.",
+        },
+        "gamble": {
+            "cost": 50,
+            "win_chance": 0.45,
+            "win_reward_coins": 120,
+            "win_reward_items": ["moss_balm", "tether_orb", "trail_morsels"],
+            "lose_reward_items": [],
+        },
+    },
+
+    # -------------------------------------------------------------------------
+    # COMBAT — COMPETITIVE
+    # -------------------------------------------------------------------------
+
+    "rival_adventurer": {
+        "name": "Rival Adventurer",
+        "title": "Guild Rival",
+        "emoji": "⚔️",
+        "type": "battle_competitive",
+        "dialogue": {
+            "greeting": "Well, well. Another Guild Adventurer. I've heard good things — let's see if the reputation holds. One battle, no hard feelings.",
+            "win": "Good fight. You've earned that. I'll remember this.",
+            "lose": "Don't take it personally. Get stronger and find me again — I'd like a rematch.",
+            "farewell": "Till next time, Adventurer.",
+        },
+        "battle": {
+            "difficulty": "medium",
+            "win_coins": 80,
+            "win_reputation": 5,
+            "lose_coins": 0,        # no penalty from rival
+        },
+    },
+
+    # -------------------------------------------------------------------------
+    # COMBAT — NEUTRAL
+    # -------------------------------------------------------------------------
+
+    "wandering_duelist": {
+        "name": "Wandering Duelist",
+        "title": "Road Duelist",
+        "emoji": "🥊",
+        "type": "battle_neutral",
+        "dialogue": {
+            "greeting": "I travel these roads for one reason — to find strong companions and test myself against them. Yours looks capable. Shall we?",
+            "win": "Impressive. You've given me something to think about on the road ahead.",
+            "lose": "Train harder. The road ahead won't be so forgiving.",
+            "farewell": "Good roads, Adventurer.",
+        },
+        "battle": {
+            "difficulty": "medium",
+            "win_coins": 60,
+            "win_reputation": 3,
+            "lose_coins": 15,       # small penalty — they take a small toll
+        },
+    },
+
+}
+
+# -----------------------------------------------------------------------------
+# PATH ENCOUNTERS
+# Per-road configuration. "pool" controls which NPCs can appear.
+# "weights" controls relative frequency (higher = more common).
+# Omitting a path uses the full WANDERING_NPCS pool at equal weight.
+# -----------------------------------------------------------------------------
+
+PATH_ENCOUNTERS = {
+
+    # Oakhaven Outpost __ Whisperwood Grove
+    "oakhavenOutpost__whisperwoodGrove": {
+        "pool": [
+            "traveling_merchant",
+            "guild_courier",
+            "field_medic",
+            "lost_adventurer",
+            "gloom_scout",
+            "rival_adventurer",
+            "wandering_duelist",
+        ],
+        "weights": [20, 15, 15, 20, 10, 10, 10],
+    },
+
+    # Whisperwood Grove __ Sunstone Oasis (stub — fill in when Town 3 is built)
+    "whisperwoodGrove__sunstoneOasis": {
+        "pool": [
+            "traveling_merchant",
+            "guild_courier",
+            "field_medic",
+            "gloom_scout",
+            "rival_adventurer",
+            "wandering_duelist",
+            "drifter",
+        ],
+        "weights": [20, 10, 15, 15, 15, 15, 10],
+    },
+
+}

--- a/migrations/011_add_last_town_id.py
+++ b/migrations/011_add_last_town_id.py
@@ -1,0 +1,14 @@
+# migrations/011_add_last_town_id.py
+
+async def apply(cursor):
+    """
+    Migration 011: Adds last_town_id to players table.
+
+    Tracks the last full town the player was in.
+    Used for defeat respawn — if a player is defeated at a Remnant,
+    they are sent back to their last known town.
+    """
+    await cursor.execute("""
+        ALTER TABLE players
+        ADD COLUMN IF NOT EXISTS last_town_id TEXT DEFAULT 'oakhavenOutpost'
+    """)

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -22,6 +22,22 @@ from data.quests import QUESTS
 from data.skills import PET_SKILLS
 from .constants import PET_IMAGE_URLS, CREST_RANKS, DEFENSIVE_TYPE_CHART
 from data.towns import TOWNS
+from data.remnants import REMNANTS
+
+
+def get_location_data(location_id: str) -> dict:
+    """Returns location data from TOWNS or REMNANTS, whichever has the id."""
+    return TOWNS.get(location_id) or REMNANTS.get(location_id) or {}
+
+
+def is_remnant(location_id: str) -> bool:
+    """Returns True if the location is a Remnant (road stop), not a town."""
+    return location_id in REMNANTS
+
+
+def get_connections(location_id: str) -> dict:
+    """Returns the connections dict for a town or remnant."""
+    return get_location_data(location_id).get('connections', {})
 
 async def get_town_embed(bot, user_id, town_id):
     """Creates a dynamic embed for a town without the status bar."""
@@ -46,6 +62,32 @@ async def get_town_embed(bot, user_id, town_id):
         embed.set_image(url=town_image_url)
     return embed
 
+async def get_remnant_embed(bot, user_id: int, remnant_id: str) -> discord.Embed:
+    """Creates a discord Embed for a Remnant road stop."""
+    db_cog = bot.get_cog('Database')
+    player_data = await db_cog.get_player(user_id)
+    time_of_day = player_data.get('day_of_cycle', 'morning') if player_data else 'morning'
+    remnant = REMNANTS.get(remnant_id, {})
+    description = (
+        remnant.get(f'description_{time_of_day}')
+        or remnant.get('description_day')
+        or remnant.get('description', 'A quiet stretch of road.')
+    )
+    embed = discord.Embed(
+        title=f"{remnant.get('emoji', '📍')} {remnant.get('name', remnant_id)}",
+        description=description,
+        color=discord.Color.dark_green()
+    )
+    gloom = remnant.get('gloom_level', 0)
+    if gloom > 0:
+        embed.add_field(
+            name="🌑 Zone Hazard: Lingering Gloom",
+            value=f"The corruption is strong here. All battles will start with **{gloom}% Gloom**.",
+            inline=False
+        )
+    return embed
+
+
 def get_player_rank_info(num_crests):
     """Determines the player's rank and provides progress info."""
     current_rank_info = CREST_RANKS[0]
@@ -69,7 +111,7 @@ def get_location_display_name(location_id: str) -> str:
     Returns a human-readable name for a location ID.
     Checks top-level towns first, then sub-location explore zones, then falls back to a clean ID format.
     """
-    # Top-level town (e.g. "oakhavenWilds", "oakhavenOutpost")
+    # Top-level town (e.g. "outpostWilds", "oakhavenOutpost")
     if location_id in TOWNS:
         return TOWNS[location_id]['name']
     # Sub-location explore zone (e.g. "oakhavenOutpost_rottingPits")


### PR DESCRIPTION
## Summary

- **Town 2 — Whisperwood Grove** fully built with 5 named locations (`leaf_lit_lodge`, `verdant_spire`, `root_branch_emporium`, `moonpetal_inn`, `whispering_thicket`), proper NPCs (Mira innkeeper, Fae Whisper, Arboreal, Elder Vexia, Slithers), and time-aware dialogue
- **Remnants system** (`data/remnants.py`) — road stops between towns: Weeping Chasm (high Gloom, Guild lore), Mirefields (semi-hostile bog, Sable NPC, shop), Glade of Whispers (peaceful, Whisperwood ↔ Sunstone), + 10 future stubs
- **Step-by-step travel redesign** — players can no longer jump directly between towns; road: `Oakhaven → Weeping Chasm → Mirefields → Whisperwood Grove`. Travel energy raised from 3 → 10. Dropdown shows ⚡ energy cost, Gloom%, and location type
- **`RemnantView`** — new full view class for Remnant road stops with Explore, Talk, and Travel buttons; NPC day/night availability
- **Defeat respawn** — new `last_town_id` column (migration 011); on defeat at a Remnant, player is teleported back to their last town with a retreat message
- **NPC availability system** — closed locations show 🔒 prefix in dropdown and a closed embed when selected
- **Wandering NPC pool** (`data/wandering_npcs.py`) — general pool of road encounter NPCs (merchant, courier, medic, duelists, etc.)
- **Misc** — `oakhavenWilds` → `outpostWilds` rename; `sunstoneOasis` fixed as proper stub; helpers extended with `get_location_data()`, `is_remnant()`, `get_remnant_embed()`

## Test plan

- [ ] `/adventure` at `oakhavenOutpost` — Travel shows only Weeping Chasm (gated behind quest flag if not completed)
- [ ] Travel to Weeping Chasm — RemnantView renders, Explore/Talk/Travel buttons appear
- [ ] Travel from Weeping Chasm → Mirefields → Whisperwood Grove (step-by-step, can't skip)
- [ ] Energy deducted correctly (10 per step)
- [ ] Lose a battle at a Remnant — player teleports back to last town with retreat message
- [ ] Win a battle at a Remnant — Remnant embed refreshes in place
- [ ] Closed locations show 🔒 in dropdown and closed embed when selected
- [ ] Mira dialogue at Moonpetal Inn changes day vs night
- [ ] Migration 011 applies cleanly on Railway deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)