### PR TITLE
staging → main: travel system, RemnantView redesign, Weeping Chasm + Mirefields

### DIFF
--- a/cogs/views/towns.py
+++ b/cogs/views/towns.py
@@ -227,7 +227,14 @@ class TravelView(discord.ui.View):
 
 
 class RemnantView(discord.ui.View):
-    """View for Remnant road stops. Simpler than TownView — no sub-locations."""
+    """
+    View for Remnant road stops.
+    Mirrors TownView — locations dropdown + Explore Area + Travel.
+    Differences: no Explore Wilds, rest lives inside sub-locations.
+    """
+
+    _DAY_PHASES   = {'morning', 'noon'}
+    _NIGHT_PHASES = {'evening', 'night'}
 
     def __init__(self, bot, parent_interaction, remnant_id):
         super().__init__(timeout=180)
@@ -236,66 +243,223 @@ class RemnantView(discord.ui.View):
         self.user_id = parent_interaction.user.id
         self.message = None
         self.remnant_id = remnant_id
+        self.current_sub_location_id = None
+
+    def _is_location_open(self, location_info: dict, time_of_day: str) -> bool:
+        avail = location_info.get('availability', 'all')
+        if avail == 'all':
+            return True
+        if avail == 'day':
+            return time_of_day in self._DAY_PHASES
+        if avail == 'night':
+            return time_of_day in self._NIGHT_PHASES
+        return avail == time_of_day
+
+    def _is_location_unlocked(self, location_info: dict, player_flags: set, active_quest_ids: set) -> bool:
+        """Returns False if the location is quest-gated and the condition isn't met."""
+        req_quest = location_info.get('required_quest')
+        if req_quest and req_quest not in active_quest_ids:
+            return False
+        req_flag = location_info.get('required_flag')
+        if req_flag and req_flag not in player_flags:
+            return False
+        return True
 
     async def initial_setup(self):
         db_cog = self.bot.get_cog('Database')
         player_data = await db_cog.get_player(self.user_id)
         time_of_day = player_data.get('day_of_cycle', 'morning') if player_data else 'morning'
-        current_energy = player_data.get('energy', 0) if player_data else 0
+        player_flags = player_data.get('flags', set()) if player_data else set()
+        active_quests = await db_cog.get_active_quests(self.user_id)
+        active_quest_ids = {q['quest_id'] for q in active_quests}
         remnant = REMNANTS.get(self.remnant_id, {})
-        services = remnant.get('services', {})
-        connections = remnant.get('connections', {})
+        self.build_ui(time_of_day, player_flags, active_quest_ids, remnant)
 
-        _DAY_PHASES   = {'morning', 'noon'}
-        _NIGHT_PHASES = {'evening', 'night'}
+    def build_ui(self, time_of_day='morning', player_flags=None, active_quest_ids=None, remnant=None):
+        self.clear_items()
+        if player_flags is None:
+            player_flags = set()
+        if active_quest_ids is None:
+            active_quest_ids = set()
+        if remnant is None:
+            remnant = REMNANTS.get(self.remnant_id, {})
 
-        # Explore button
-        if 'explore_zone' in services:
-            explore_btn = discord.ui.Button(label="Explore Area", style=discord.ButtonStyle.green, emoji="🌲")
-            explore_btn.callback = self.explore_callback
-            self.add_item(explore_btn)
+        if self.current_sub_location_id:
+            # --- Sub-location view ---
+            location_info = remnant.get('locations', {}).get(self.current_sub_location_id, {})
+            services = location_info.get('services', {})
 
-        # NPC talk buttons
-        for npc_id, npc_data in remnant.get('npcs', {}).items():
-            avail = npc_data.get('availability', 'all')
-            if avail == 'all':
-                available = True
-            elif avail == 'day':
-                available = time_of_day in _DAY_PHASES
-            elif avail == 'night':
-                available = time_of_day in _NIGHT_PHASES
-            else:
-                available = avail == time_of_day
-            btn = discord.ui.Button(
-                label=f"Talk to {npc_data['name']}",
-                style=discord.ButtonStyle.secondary,
-                disabled=not available
-            )
-            btn.callback = self._make_talk_callback(npc_id, npc_data)
-            self.add_item(btn)
+            if 'explore_zone' in services:
+                btn = discord.ui.Button(label="Explore Area", style=discord.ButtonStyle.green, emoji="🌲")
+                btn.callback = self.explore_callback
+                self.add_item(btn)
 
-        # Rest button — show when energy is too low to afford any outgoing route
-        if 'rest_energy' in remnant and connections:
-            default_cost = ACTION_COSTS.get("travel", {}).get("energy", 10)
-            min_travel_cost = min(
-                get_travel_cost(self.remnant_id, loc_id, default_cost)
-                for loc_id in connections
-            )
-            if current_energy < min_travel_cost:
-                rest_btn = discord.ui.Button(label="Rest", style=discord.ButtonStyle.secondary, emoji="🔥")
-                rest_btn.callback = self.rest_callback
-                self.add_item(rest_btn)
+            if 'shop' in services:
+                btn = discord.ui.Button(label="Shop", style=discord.ButtonStyle.blurple, emoji="🛒")
+                btn.callback = self.shop_callback
+                self.add_item(btn)
 
-        # Travel button
-        travel_btn = discord.ui.Button(label="Travel", style=discord.ButtonStyle.blurple, emoji="🗺️")
-        travel_btn.callback = self.travel_callback
-        self.add_item(travel_btn)
+            if 'rest' in services:
+                btn = discord.ui.Button(label="Rest", style=discord.ButtonStyle.secondary, emoji="🔥")
+                btn.callback = self.rest_callback
+                self.add_item(btn)
+
+            for npc_id, npc_data in location_info.get('npcs', {}).items():
+                avail = npc_data.get('availability', 'all')
+                if avail == 'all':
+                    available = True
+                elif avail == 'day':
+                    available = time_of_day in self._DAY_PHASES
+                elif avail == 'night':
+                    available = time_of_day in self._NIGHT_PHASES
+                else:
+                    available = avail == time_of_day
+                btn = discord.ui.Button(
+                    label=f"Talk to {npc_data['name']}",
+                    style=discord.ButtonStyle.secondary,
+                    disabled=not available
+                )
+                btn.callback = self._make_talk_callback(npc_id, npc_data)
+                self.add_item(btn)
+
+            back_btn = discord.ui.Button(label="Back", style=discord.ButtonStyle.grey, emoji="↩️")
+            back_btn.callback = self.back_callback
+            self.add_item(back_btn)
+
+        else:
+            # --- Remnant hub view ---
+            locations = remnant.get('locations', {})
+            options = []
+            for loc_id, loc_data in locations.items():
+                is_open = self._is_location_open(loc_data, time_of_day)
+                is_unlocked = self._is_location_unlocked(loc_data, player_flags, active_quest_ids)
+                if not is_unlocked:
+                    label = f"🔒 {loc_data['name']}"
+                elif not is_open:
+                    label = f"🔒 {loc_data['name']}"
+                else:
+                    label = loc_data['name']
+                options.append(discord.SelectOption(
+                    label=label,
+                    value=loc_id,
+                    description=loc_data.get('menu_description'),
+                    emoji=loc_data.get('emoji'),
+                ))
+            if options:
+                select = discord.ui.Select(placeholder="Explore this area...", options=options)
+                select.callback = self.select_location_callback
+                self.add_item(select)
+
+            # Explore Area button — only if remnant itself has a top-level explore zone
+            # (remnants without locations use this; those with locations use sub-location explore)
+            top_level_explore = remnant.get('services', {}).get('explore_zone') if not locations else None
+            if top_level_explore:
+                btn = discord.ui.Button(label="Explore Area", style=discord.ButtonStyle.green, emoji="🌲")
+                btn.callback = self.explore_callback
+                self.add_item(btn)
+
+            travel_btn = discord.ui.Button(label="Travel", style=discord.ButtonStyle.blurple, emoji="🗺️")
+            travel_btn.callback = self.travel_callback
+            self.add_item(travel_btn)
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         if interaction.user.id != self.user_id:
             await interaction.response.send_message("This is not your menu!", ephemeral=True)
             return False
         return True
+
+    async def select_location_callback(self, interaction: discord.Interaction):
+        await interaction.response.defer()
+        self.current_sub_location_id = interaction.data['values'][0]
+        db_cog = self.bot.get_cog('Database')
+        player_data = await db_cog.get_player(self.user_id)
+        time_of_day = player_data.get('day_of_cycle', 'morning') if player_data else 'morning'
+        player_flags = player_data.get('flags', set()) if player_data else set()
+        active_quests = await db_cog.get_active_quests(self.user_id)
+        active_quest_ids = {q['quest_id'] for q in active_quests}
+        remnant = REMNANTS.get(self.remnant_id, {})
+        location_info = remnant.get('locations', {}).get(self.current_sub_location_id, {})
+
+        # Quest-gated — not yet unlocked
+        if not self._is_location_unlocked(location_info, player_flags, active_quest_ids):
+            embed = discord.Embed(
+                title=f"🔒 {location_info.get('name', 'Location')}",
+                description="*There's nothing here for you yet.*",
+                color=discord.Color.dark_gray()
+            )
+            embed.set_footer(text="Complete the required quest to access this area.")
+            self.clear_items()
+            back_btn = discord.ui.Button(label="Back", style=discord.ButtonStyle.grey, emoji="↩️")
+            back_btn.callback = self.back_callback
+            self.add_item(back_btn)
+            await interaction.edit_original_response(embed=embed, view=self)
+            return
+
+        # Time-gated — closed right now
+        if not self._is_location_open(location_info, time_of_day):
+            closed_desc = (
+                location_info.get(f'description_{time_of_day}')
+                or location_info.get('description_night')
+                or location_info.get('description_day')
+                or "This area is inaccessible right now."
+            )
+            embed = discord.Embed(
+                title=f"🔒 {location_info.get('name', 'Location')}",
+                description=closed_desc,
+                color=discord.Color.dark_gray()
+            )
+            embed.set_footer(text="Come back at a different time.")
+            self.clear_items()
+            back_btn = discord.ui.Button(label="Back", style=discord.ButtonStyle.grey, emoji="↩️")
+            back_btn.callback = self.back_callback
+            self.add_item(back_btn)
+            await interaction.edit_original_response(embed=embed, view=self)
+            return
+
+        new_embed = await self._build_sublocation_embed(location_info)
+        self.build_ui(time_of_day, player_flags, active_quest_ids, remnant)
+        await interaction.edit_original_response(embed=new_embed, view=self)
+
+    async def _build_sublocation_embed(self, location_info: dict):
+        db_cog = self.bot.get_cog('Database')
+        player_data = await db_cog.get_player(self.user_id)
+        time_of_day = player_data.get('day_of_cycle', 'morning') if player_data else 'morning'
+        description = (
+            location_info.get(f'description_{time_of_day}')
+            or location_info.get('description_day')
+            or location_info.get('description', 'A quiet spot.')
+        )
+        embed = discord.Embed(
+            title=f"{location_info.get('emoji', '📍')} {location_info['name']}",
+            description=description,
+            color=discord.Color.dark_teal()
+        )
+        gloom = location_info.get('services', {}).get('gloom_level', 0)
+        if gloom:
+            embed.color = discord.Color.dark_purple()
+            embed.add_field(
+                name="🌑 Zone Hazard: Lingering Gloom",
+                value=f"All battles here start with **{gloom}% Gloom**.",
+                inline=False
+            )
+        player_and_pet_data = await db_cog.get_player_and_pet_data(self.user_id)
+        if player_and_pet_data:
+            embed.set_footer(text=get_status_bar(
+                player_and_pet_data['player_data'], player_and_pet_data['main_pet_data']
+            ))
+        return embed
+
+    async def back_callback(self, interaction: discord.Interaction):
+        await interaction.response.defer()
+        self.current_sub_location_id = None
+        new_embed = await get_remnant_embed(self.bot, self.user_id, self.remnant_id)
+        player_and_pet_data = await self.bot.get_cog('Database').get_player_and_pet_data(self.user_id)
+        if player_and_pet_data:
+            new_embed.set_footer(text=get_status_bar(
+                player_and_pet_data['player_data'], player_and_pet_data['main_pet_data']
+            ))
+        await self.initial_setup()
+        await interaction.edit_original_response(embed=new_embed, view=self)
 
     def _make_talk_callback(self, npc_id, npc_data):
         async def callback(interaction: discord.Interaction):
@@ -304,9 +468,7 @@ class RemnantView(discord.ui.View):
             player_data = await db_cog.get_player(self.user_id)
             time_of_day = player_data.get('day_of_cycle', 'morning') if player_data else 'morning'
             dialogue = npc_data.get('dialogue', {})
-            text = (dialogue.get(time_of_day)
-                    or dialogue.get('default')
-                    or "...")
+            text = dialogue.get(time_of_day) or dialogue.get('default') or "..."
             embed = discord.Embed(
                 title=f"{npc_data.get('emoji', '💬')} {npc_data['name']}",
                 description=f"*\"{text}\"*",
@@ -317,47 +479,50 @@ class RemnantView(discord.ui.View):
 
     async def explore_callback(self, interaction: discord.Interaction):
         remnant = REMNANTS.get(self.remnant_id, {})
-        zone_id = remnant.get('services', {}).get('explore_zone', self.remnant_id)
+        # Use sub-location's explore_zone if inside one, else fall back to remnant id
+        if self.current_sub_location_id:
+            zone_id = remnant.get('locations', {}).get(
+                self.current_sub_location_id, {}
+            ).get('services', {}).get('explore_zone', self.remnant_id)
+        else:
+            zone_id = remnant.get('services', {}).get('explore_zone', self.remnant_id)
         adventure_cog = self.bot.get_cog('Adventure')
         if adventure_cog:
             await adventure_cog.explore(interaction, zone_id, view_context=self)
+
+    async def shop_callback(self, interaction: discord.Interaction):
+        await interaction.response.defer(ephemeral=True)
+        remnant = REMNANTS.get(self.remnant_id, {})
+        location_info = remnant.get('locations', {}).get(self.current_sub_location_id, {})
+        from .shop import ShopView
+        shop_view = ShopView(self.bot, self.user_id, self.parent_interaction, location_info)
+        await shop_view.rebuild_ui()
+        embed = await shop_view.build_embed()
+        msg = await interaction.followup.send(embed=embed, view=shop_view, ephemeral=True)
+        shop_view.message = msg
 
     async def rest_callback(self, interaction: discord.Interaction):
         await interaction.response.defer()
         db_cog = self.bot.get_cog('Database')
         remnant = REMNANTS.get(self.remnant_id, {})
-        rest_energy = remnant.get('rest_energy', 20)
-        flavor = remnant.get('rest_flavor', "You take a moment to catch your breath.")
+        location_info = remnant.get('locations', {}).get(self.current_sub_location_id, {})
+        rest_cfg = location_info.get('services', {}).get('rest', {})
+        energy_restore = rest_cfg.get('energy_restore', 20)
+        flavor = rest_cfg.get('flavor', "You take a moment to catch your breath.")
 
         player_data = await db_cog.get_player(self.user_id)
         max_energy = player_data.get('max_energy', 100)
         current_energy = player_data.get('energy', 0)
-        restored = min(rest_energy, max_energy - current_energy)
-        new_energy = current_energy + restored
+        restored = min(energy_restore, max_energy - current_energy)
+        await db_cog.update_player(self.user_id, energy=current_energy + restored)
 
-        await db_cog.update_player(self.user_id, energy=new_energy)
-
-        # Rebuild embed + view with updated state
-        new_embed = await get_remnant_embed(self.bot, self.user_id, self.remnant_id)
+        new_embed = await self._build_sublocation_embed(location_info)
         new_embed.add_field(
             name="🔥 Rested",
             value=f"*{flavor}*\n\n+**{restored} energy** restored.",
             inline=False
         )
-        player_and_pet_data = await db_cog.get_player_and_pet_data(self.user_id)
-        if player_and_pet_data:
-            new_embed.set_footer(text=get_status_bar(
-                player_and_pet_data['player_data'], player_and_pet_data['main_pet_data']
-            ))
-
-        # Rebuild buttons — Rest may disappear if energy is now sufficient
-        self.clear_items()
-        await self.initial_setup()
-
-        try:
-            await self.message.edit(embed=new_embed, view=self)
-        except (discord.NotFound, discord.HTTPException):
-            pass
+        await interaction.edit_original_response(embed=new_embed, view=self)
 
     async def travel_callback(self, interaction: discord.Interaction):
         await interaction.response.defer(ephemeral=True)
@@ -365,10 +530,17 @@ class RemnantView(discord.ui.View):
         player_data = await db_cog.get_player(self.user_id)
         remnant = REMNANTS.get(self.remnant_id, {})
         connections = remnant.get('connections', {})
+        connection_reqs = remnant.get('connection_requirements', {})
+        player_flags = player_data.get('flags', set())
+
+        # Filter locked connections
+        connections = {
+            loc_id: name for loc_id, name in connections.items()
+            if loc_id not in connection_reqs or connection_reqs[loc_id] in player_flags
+        }
         if not connections:
             return await interaction.followup.send("There's nowhere to go from here.", ephemeral=True)
 
-        # Check energy against cheapest available route
         default_cost = ACTION_COSTS.get("travel", {}).get("energy", 10)
         min_cost = min(get_travel_cost(self.remnant_id, loc_id, default_cost) for loc_id in connections)
         if player_data.get('energy', 0) < min_cost:

--- a/data/remnants.py
+++ b/data/remnants.py
@@ -27,20 +27,13 @@ REMNANTS = {
             "oakhavenOutpost": "Oakhaven Outpost",
             "mirefields": "Mirefields",
         },
-        # Per-route energy costs. Falls back to ACTION_COSTS["travel"]["energy"] if not set.
-        # Going back to Oakhaven is slightly cheaper (familiar road).
-        # Pushing forward into the Mirefields costs more.
         "connection_costs": {
             "oakhavenOutpost": 8,
             "mirefields": 14,
         },
-        # Rest at this Remnant: energy restore only, no HP, no time skip.
-        "rest_energy": 20,
-        "rest_flavor": (
-            "You find a stable outcrop of rock away from the Chasm's edge and sit down. "
-            "The cold mist is unsettling, but stillness returns to your limbs. "
-            "Warden Orin nods from his post without a word."
-        ),
+        "connection_requirements": {
+            "mirefields": "quest_a_guildsmans_first_steps_completed",
+        },
         "availability": "all",
         "gloom_level": 25,
         "description_day": (
@@ -54,32 +47,172 @@ REMNANTS = {
             "the trees lean away. The mist thickens into something almost visible, and the "
             "darkness below feels aware of you."
         ),
-        "lore": (
-            "This is where it began. Centuries ago, a crack formed in the bedrock and the "
-            "first tendrils of The Gloom seeped upward. The Guild sealed what they could, "
-            "but the scar never healed."
-        ),
-        "npcs": {
-            "chasm_warden": {
-                "name": "Warden Orin",
-                "role": "Guild Warden",
+        # -----------------------------------------------------------------
+        # Locations — same pattern as towns.py
+        # Availability: 'all' | 'day' | 'night'
+        # required_flag: greyed out until player has this flag
+        # required_quest: greyed out until this quest is active
+        # -----------------------------------------------------------------
+        "locations": {
+            "chasms_edge": {
+                "name": "The Chasm's Edge",
+                "emoji": "🕳️",
+                "menu_description": "The lip of the Chasm. Cold. The source of the Gloom.",
+                "availability": "all",
+                "description_day": (
+                    "A narrow ledge of cracked stone along the chasm's rim. The Guild has "
+                    "bolted warning markers into the rock, but most have tilted with the "
+                    "settling ground. The air here smells of cold metal and something older."
+                ),
+                "description_night": (
+                    "The mist curls upward around your ankles. The darkness below is total. "
+                    "Nothing attacks. Something is just checking."
+                ),
+                "services": {
+                    "explore_zone": "weeping_chasm",
+                    "gloom_level": 25,
+                },
+                "npcs": {},
+            },
+
+            "wardens_post": {
+                "name": "The Warden's Post",
                 "emoji": "🛡️",
+                "menu_description": "Warden Orin's watch station. Manned during daylight hours.",
                 "availability": "day",
-                "dialogue": {
-                    "default": (
-                        "This is as close as most people get. The Chasm draws Gloom-Touched "
-                        "creatures — they're drawn to the source. I keep watch so travelers "
-                        "can pass safely. Mostly."
-                    ),
-                    "lore_prompt": (
-                        "The records say The Gloom first surfaced here. I believe it. "
-                        "Some nights I can feel it thinking."
-                    ),
-                }
-            }
-        },
-        "services": {
-            "explore_zone": "weeping_chasm",
+                "description_day": (
+                    "A solid Guild-issue post: a small fire, a folding chair, a logbook "
+                    "worn thin from use. Warden Orin keeps his eyes on the Chasm with the "
+                    "patience of someone who has been doing this a long time."
+                ),
+                "description_night": (
+                    "A folded note is pinned to the post with a Guild insignia pin.\n\n"
+                    "*\"Gone at dark. You should be too. — O.\"*"
+                ),
+                "services": {},
+                "npcs": {
+                    "warden_orin": {
+                        "name": "Warden Orin",
+                        "role": "Guild Warden",
+                        "emoji": "🛡️",
+                        "availability": "day",
+                        "dialogue": {
+                            "default": (
+                                "This is as close as most people get. The Chasm draws "
+                                "Gloom-Touched creatures — they're drawn to the source. "
+                                "I keep watch so travelers can pass safely. Mostly."
+                            ),
+                            "lore_prompt": (
+                                "The records say The Gloom first surfaced here. I believe it. "
+                                "Some nights I can feel it thinking."
+                            ),
+                            "returning_recruit": (
+                                "Ah — a Guild recruit. Good. The road east gets worse before "
+                                "it gets better. Keep your pet fed and your energy up."
+                            ),
+                        },
+                    },
+                },
+            },
+
+            "scholars_camp": {
+                "name": "The Scholar's Camp",
+                "emoji": "📜",
+                "menu_description": "A field researcher's camp. Appears occupied — sometimes.",
+                "availability": "all",
+                "required_quest": "echoes_from_below",   # greyed until quest is active
+                "description_day": (
+                    "A small camp pressed against the rock face away from the wind. "
+                    "Notebooks, vials, and equipment cases are stacked with the organised "
+                    "chaos of someone who knows exactly where everything is. "
+                    "A lamp burns low on a flat stone."
+                ),
+                "description_night": (
+                    "The lamp is still burning. The notebooks are still open. "
+                    "Kael doesn't sleep much when he's onto something."
+                ),
+                "services": {},
+                "npcs": {
+                    "lore_keeper_kael": {
+                        "name": "Lore-Keeper Kael",
+                        "role": "Guild Scholar",
+                        "emoji": "🔬",
+                        "availability": "all",
+                        "dialogue": {
+                            "default": (
+                                "You found me. Good — I wasn't sure Vexia would send anyone "
+                                "capable. The origin point is right here and nobody bothers "
+                                "to study it properly. I need samples. Three vials of "
+                                "gloom-mist from the Edge. Can you do that?"
+                            ),
+                            "samples_collected": (
+                                "These are clean samples — remarkable. The density here is "
+                                "unlike anything recorded further out. When you reach the "
+                                "Oasis, find the Obsidian Monoliths. I'll be there. "
+                                "There's something I need to show you."
+                            ),
+                        },
+                    },
+                },
+            },
+
+            "lookout_hollow": {
+                "name": "The Lookout Hollow",
+                "emoji": "🗡️",
+                "menu_description": "A weathered hollow. Someone has been here a long time.",
+                "availability": "all",
+                "description_day": (
+                    "A natural depression in the rock, sheltered from the wind and set back "
+                    "from the Chasm. It's been lived in — a fire ring, a bedroll, a row of "
+                    "marked stones that might be a personal tallying system. "
+                    "Gretta is here, as she always is."
+                ),
+                "description_night": (
+                    "The fire is low but steady. Gretta is awake. "
+                    "She's always awake at night — she learned not to sleep deeply here "
+                    "a long time ago."
+                ),
+                "services": {
+                    "rest": {
+                        "type": "rough_camp",
+                        "cost": 0,
+                        "energy_restore": 20,
+                        "health_restore_percent": 0,
+                        "flavor": (
+                            "Gretta gestures at a flat rock near the fire without looking up. "
+                            "*\"Sit. Don't talk.\"* "
+                            "You rest in silence. It's enough."
+                        ),
+                    },
+                },
+                "npcs": {
+                    "grim_gretta": {
+                        "name": "\"Grim\" Gretta",
+                        "role": "Chasm Watcher",
+                        "emoji": "🗡️",
+                        "availability": "all",
+                        "dialogue": {
+                            "default": (
+                                "Guild sends another one. They always look the same — "
+                                "hopeful. The Chasm fixes that eventually. "
+                                "What do you want?"
+                            ),
+                            "player_has_pet": (
+                                "That creature following you — you trust it? "
+                                "The Gloom finds the ones you're attached to first. "
+                                "Keep it strong. Soft bonds don't survive this road."
+                            ),
+                            "subdue_path_intro": (
+                                "You want to know what I know? Fine. "
+                                "The Guild tells you to heal corrupted creatures. "
+                                "I've watched that fail more times than you've been alive. "
+                                "Control is not cruelty. It's honesty. "
+                                "There's another way — if you're willing to hear it."
+                            ),
+                        },
+                    },
+                },
+            },
         },
     },
 
@@ -92,20 +225,10 @@ REMNANTS = {
             "weeping_chasm": "Weeping Chasm",
             "whisperwoodGrove": "Whisperwood Grove",
         },
-        # Per-route energy costs.
-        # Backtracking to the Chasm is uphill and tiring.
-        # Pushing through to Whisperwood requires navigating thick boggy terrain.
         "connection_costs": {
             "weeping_chasm": 12,
             "whisperwoodGrove": 14,
         },
-        # Rest at this Remnant: energy restore only, no HP, no time skip.
-        "rest_energy": 20,
-        "rest_flavor": (
-            "Sable tosses you a strip of dried bark to chew on and points to a dry log. "
-            "You sit in silence while the fog drifts past. "
-            "It's not comfortable, but it's enough to push on."
-        ),
         "availability": "all",
         "gloom_level": 8,
         "description_day": (
@@ -121,34 +244,78 @@ REMNANTS = {
             "the occasional splash of something moving through the water. "
             "Not the place to stop and rest."
         ),
-        "lore": (
-            "Once a busy waystation for traders moving between Oakhaven and the forests "
-            "beyond. When the road fell out of use, the mire moved in. "
-            "A few stubborn souls still pass through — and a few still live here."
-        ),
-        "npcs": {
-            "sable": {
-                "name": "Sable",
-                "role": "Bog Trapper",
-                "emoji": "🪤",
+        "locations": {
+            "bogside_trail": {
+                "name": "The Bogside Trail",
+                "emoji": "🌫️",
+                "menu_description": "The main stretch through the mire. Creatures lurk nearby.",
                 "availability": "all",
-                "dialogue": {
-                    "default": (
-                        "You lost? Most people don't come through here by choice. "
-                        "I've got supplies if you need them — nothing fancy, but it'll keep you alive."
-                    ),
-                    "night": (
-                        "You're braver than most, traveling through here at night. "
-                        "Or dumber. Hard to tell. Watch your step — the mire shifts after dark."
-                    ),
-                    "sell": "Take what you need and move on. I don't do small talk.",
-                }
-            }
-        },
-        "services": {
-            "explore_zone": "mirefields",
-            "shop": True,
-            "shop_items": ["moss_balm", "trail_morsels", "tether_orb"],
+                "description_day": (
+                    "The road narrows to a muddy track hemmed in by twisted undergrowth. "
+                    "The ground shifts unpredictably underfoot. Territorial creatures "
+                    "watch from the fog — not Gloom-touched, just mean and hungry."
+                ),
+                "description_night": (
+                    "The trail is nearly invisible in the dark. Every sound is amplified. "
+                    "Moving through here at night requires patience and a steady pet."
+                ),
+                "services": {
+                    "explore_zone": "mirefields",
+                    "gloom_level": 8,
+                },
+                "npcs": {},
+            },
+
+            "sables_post": {
+                "name": "Sable's Post",
+                "emoji": "🪤",
+                "menu_description": "A trapper's camp off the main trail. Supplies available.",
+                "availability": "all",
+                "description_day": (
+                    "A compact camp built from salvaged wood and waterproofed canvas. "
+                    "Traps and pelts hang from a line. Sable runs a lean operation — "
+                    "everything here has a purpose."
+                ),
+                "description_night": (
+                    "The camp lantern is on. Sable keeps late hours. "
+                    "Half the road traffic passes through at night, and she knows it."
+                ),
+                "services": {
+                    "shop": True,
+                    "shop_items": ["moss_balm", "trail_morsels", "tether_orb"],
+                    "rest": {
+                        "type": "rough_camp",
+                        "cost": 0,
+                        "energy_restore": 20,
+                        "health_restore_percent": 0,
+                        "flavor": (
+                            "Sable tosses you a strip of dried bark to chew on and points "
+                            "to a dry log. You sit in silence while the fog drifts past. "
+                            "*\"Don't get comfortable.\"*"
+                        ),
+                    },
+                },
+                "npcs": {
+                    "sable": {
+                        "name": "Sable",
+                        "role": "Bog Trapper",
+                        "emoji": "🪤",
+                        "availability": "all",
+                        "dialogue": {
+                            "default": (
+                                "You lost? Most people don't come through here by choice. "
+                                "I've got supplies if you need them — nothing fancy, "
+                                "but it'll keep you alive."
+                            ),
+                            "night": (
+                                "You're braver than most, traveling through here at night. "
+                                "Or dumber. Hard to tell. Watch your step — the mire shifts after dark."
+                            ),
+                            "sell": "Take what you need and move on. I don't do small talk.",
+                        },
+                    },
+                },
+            },
         },
     },
 


### PR DESCRIPTION
## Summary

- **Travel energy deduction** — energy now actually spent on arrival, was only checked before
- **Dynamic per-route costs** — `connection_costs` dict per location, different costs per direction
- **Locked routes in dropdown** — unaffordable destinations show `🔒 Name`, selecting one shows energy error
- **RemnantView redesign** — now mirrors TownView: locations dropdown + Explore Area + Travel button
- **Weeping Chasm** — 4 locations: Chasm's Edge (explore), Warden's Post (Orin, day only), Scholar's Camp (Kael, quest-gated), Lookout Hollow (Gretta, always + rest)
- **Mirefields** — 2 locations: Bogside Trail (explore), Sable's Post (shop + rest)
- **Rest is character-driven** — lives inside sub-locations, tied to NPCs (Gretta, Sable), not a standalone button
- **connection_requirements on Weeping Chasm** — forward travel to Mirefields gated behind quest flag
- **Fix: Explore Wilds button missing at Oakhaven Outpost** — outpostWilds re-added to connections

## Test plan

- [ ] Oakhaven Outpost shows Explore Wilds + Travel buttons
- [ ] Travel dropdown shows per-route costs, locked routes show 🔒
- [ ] Selecting locked route shows energy error, no movement
- [ ] Energy deducted correctly on arrival
- [ ] `/adventure` at weeping_chasm or mirefields loads RemnantView with locations dropdown
- [ ] Weeping Chasm: Chasm's Edge opens explore, Warden's Post locked at night, Scholar's Camp locked without quest, Lookout Hollow always open
- [ ] Lookout Hollow: Gretta talk + Rest button restores energy only
- [ ] Mirefields: Bogside Trail explore, Sable's Post shop + rest
- [ ] Back button returns to remnant hub
- [ ] Travel button respects connection_requirements (Mirefields locked until quest flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)