### PR TITLE
Mirefields foundation + on_enter system + UI layout fixes

### DIFF
--- a/cogs/adventure.py
+++ b/cogs/adventure.py
@@ -140,10 +140,22 @@ class Adventure(commands.Cog):
             if is_well_rested:
                 activity_log_list.append(get_notification("PLAYER_BUFF_WELL_RESTED"))
 
+            time_of_day = player_data.get('day_of_cycle', 'morning')
+            is_night_time = time_of_day in ('evening', 'night')
+
             if outcome == "flavor_event":
+                # Filter events by time — events with no "time" key fire any time
+                eligible_events = [
+                    e for e in zone_events
+                    if 'time' not in e
+                    or (e['time'] == 'night' and is_night_time)
+                    or (e['time'] == 'day' and not is_night_time)
+                ]
+                if not eligible_events:
+                    eligible_events = zone_events  # fallback — never leave the pool empty
                 chosen_event = random.choices(
-                    zone_events,
-                    weights=[e.get("weight", 5) for e in zone_events],
+                    eligible_events,
+                    weights=[e.get("weight", 5) for e in eligible_events],
                     k=1
                 )[0]
                 await self._handle_flavor_event(interaction, user_id, db_cog, chosen_event, activity_log_list, view_context)
@@ -196,10 +208,10 @@ class Adventure(commands.Cog):
                 if outcome == "tutorial_pet":
                     chosen_species_name, level = "Pineling", 1
                 else:
-                    time_of_day = player_data.get('day_of_cycle', 'morning')
+                    # time_of_day already resolved above
                     # Map 4 phases to encounter table keys (day/night)
                     # Encounter tables can add 'morning'/'noon'/etc keys later for unique spawns
-                    encounter_key = 'night' if time_of_day == 'night' else 'day'
+                    encounter_key = 'night' if is_night_time else 'day'
                     possible_pet_names = (ENCOUNTER_TABLES.get(location_id, {}).get(time_of_day)
                                           or ENCOUNTER_TABLES.get(location_id, {}).get(encounter_key, []))
                     if not possible_pet_names:

--- a/cogs/views/towns.py
+++ b/cogs/views/towns.py
@@ -356,7 +356,7 @@ class RemnantView(discord.ui.View):
                     emoji=loc_data.get('emoji'),
                 ))
             if options:
-                select = discord.ui.Select(placeholder="Explore this area...", options=options)
+                select = discord.ui.Select(placeholder="🔍 Explore this area...", options=options)
                 select.callback = self.select_location_callback
                 self.add_item(select)
 
@@ -459,6 +459,62 @@ class RemnantView(discord.ui.View):
         self.build_ui(time_of_day, player_flags, active_quest_ids, remnant)
         await interaction.edit_original_response(embed=new_embed, view=self)
 
+        # on_enter — fire matching auto-dialogue as a separate ephemeral pop
+        on_enter_text = await self._resolve_on_enter(
+            location_info, player_data, player_flags, time_of_day, db_cog
+        )
+        if on_enter_text:
+            await interaction.followup.send(on_enter_text, ephemeral=True)
+
+    async def _resolve_on_enter(self, location_info, player_data, player_flags, time_of_day, db_cog):
+        """Check on_enter conditions and return the first matching text, or None."""
+        on_enter = location_info.get('on_enter', [])
+        if not on_enter:
+            return None
+
+        player_and_pet = await db_cog.get_player_and_pet_data(self.user_id)
+        active_pet_species = None
+        if player_and_pet and player_and_pet.get('main_pet_data'):
+            active_pet_species = player_and_pet['main_pet_data'].get('species')
+
+        for entry in on_enter:
+            condition = entry.get('condition', '')
+            text = entry.get('text', '')
+            flag = entry.get('flag')
+            once = entry.get('once', False)
+
+            matched = False
+
+            if condition == 'first_visit':
+                if flag and flag not in player_flags:
+                    matched = True
+            elif condition.startswith('has_pet_species:'):
+                species = condition.split(':', 1)[1]
+                if active_pet_species == species:
+                    # once=True: only fire if the flag hasn't been set yet
+                    if once and flag:
+                        matched = flag not in player_flags
+                    else:
+                        matched = True
+            elif condition.startswith('flag:'):
+                check_flag = condition.split(':', 1)[1]
+                matched = check_flag in player_flags
+            elif condition.startswith('no_flag:'):
+                check_flag = condition.split(':', 1)[1]
+                matched = check_flag not in player_flags
+            elif condition == 'time:day':
+                matched = time_of_day in self._DAY_PHASES
+            elif condition == 'time:night':
+                matched = time_of_day in self._NIGHT_PHASES
+
+            if matched and text:
+                # Set flag if required (first_visit or once=True entries)
+                if flag and (condition == 'first_visit' or once):
+                    await db_cog.set_flag(self.user_id, flag)
+                return text
+
+        return None
+
     async def _build_sublocation_embed(self, location_info: dict):
         db_cog = self.bot.get_cog('Database')
         player_data = await db_cog.get_player(self.user_id)
@@ -531,8 +587,24 @@ class RemnantView(discord.ui.View):
 
     async def shop_callback(self, interaction: discord.Interaction):
         await interaction.response.defer(ephemeral=True)
+        db_cog = self.bot.get_cog('Database')
+        player_data = await db_cog.get_player(self.user_id)
+        time_of_day = player_data.get('day_of_cycle', 'morning') if player_data else 'morning'
+        is_night = time_of_day in self._NIGHT_PHASES
+
         remnant = REMNANTS.get(self.remnant_id, {})
         location_info = remnant.get('locations', {}).get(self.current_sub_location_id, {})
+        services = location_info.get('services', {})
+
+        # Resolve time-aware item list
+        if is_night and 'shop_items_night' in services:
+            items_for_sale = services['shop_items_night']
+        else:
+            items_for_sale = services.get('shop_items', services.get('items_for_sale', []))
+
+        # Inject resolved list as items_for_sale so ShopView reads it correctly
+        location_info = {**location_info, 'items_for_sale': items_for_sale}
+
         from .shop import ShopView
         shop_view = ShopView(self.bot, self.user_id, self.parent_interaction, location_info)
         await shop_view.rebuild_ui()
@@ -866,13 +938,6 @@ class TownView(discord.ui.View):
                 select = discord.ui.Select(placeholder="🔍 Explore locations in town...", options=location_options)
                 select.callback = self.select_location_callback
                 self.add_item(select)
-            wilds_id = next(
-                (loc_id for loc_id in town_info.get('connections', {}) if TOWNS.get(loc_id, {}).get('is_wilds')), None)
-            if wilds_id:
-                explore_wilds_button = discord.ui.Button(label="Explore Wilds", style=discord.ButtonStyle.green,
-                                                         emoji="🌲")
-                explore_wilds_button.callback = self.explore_wilds_callback
-                self.add_item(explore_wilds_button)
 
             # Inline travel dropdown — replaces Travel button
             all_connections = town_info.get('connections', {})
@@ -904,6 +969,15 @@ class TownView(discord.ui.View):
                 travel_select = discord.ui.Select(placeholder="🗺️ Travel to...", options=travel_options)
                 travel_select.callback = self.inline_travel_callback
                 self.add_item(travel_select)
+
+            # Explore Wilds button goes after both dropdowns
+            wilds_id = next(
+                (loc_id for loc_id in town_info.get('connections', {}) if TOWNS.get(loc_id, {}).get('is_wilds')), None)
+            if wilds_id:
+                explore_wilds_button = discord.ui.Button(label="Explore Wilds", style=discord.ButtonStyle.green,
+                                                         emoji="🌲")
+                explore_wilds_button.callback = self.explore_wilds_callback
+                self.add_item(explore_wilds_button)
 
     async def explore_wilds_callback(self, interaction: discord.Interaction):
         await interaction.response.defer()
@@ -998,6 +1072,61 @@ class TownView(discord.ui.View):
         self.build_ui()
         await interaction.edit_original_response(embed=new_embed, view=self)
 
+        # on_enter — fire matching auto-dialogue as a separate ephemeral pop
+        player_flags = player_data.get('flags', set()) if player_data else set()
+        on_enter_text = await self._resolve_on_enter(
+            location_info, player_data, player_flags, time_of_day, db_cog
+        )
+        if on_enter_text:
+            await interaction.followup.send(on_enter_text, ephemeral=True)
+
+    async def _resolve_on_enter(self, location_info, player_data, player_flags, time_of_day, db_cog):
+        """Check on_enter conditions and return the first matching text, or None."""
+        on_enter = location_info.get('on_enter', [])
+        if not on_enter:
+            return None
+
+        player_and_pet = await db_cog.get_player_and_pet_data(self.user_id)
+        active_pet_species = None
+        if player_and_pet and player_and_pet.get('main_pet_data'):
+            active_pet_species = player_and_pet['main_pet_data'].get('species')
+
+        for entry in on_enter:
+            condition = entry.get('condition', '')
+            text = entry.get('text', '')
+            flag = entry.get('flag')
+            once = entry.get('once', False)
+
+            matched = False
+
+            if condition == 'first_visit':
+                if flag and flag not in player_flags:
+                    matched = True
+            elif condition.startswith('has_pet_species:'):
+                species = condition.split(':', 1)[1]
+                if active_pet_species == species:
+                    if once and flag:
+                        matched = flag not in player_flags
+                    else:
+                        matched = True
+            elif condition.startswith('flag:'):
+                check_flag = condition.split(':', 1)[1]
+                matched = check_flag in player_flags
+            elif condition.startswith('no_flag:'):
+                check_flag = condition.split(':', 1)[1]
+                matched = check_flag not in player_flags
+            elif condition == 'time:day':
+                matched = time_of_day in self._DAY_PHASES
+            elif condition == 'time:night':
+                matched = time_of_day in self._NIGHT_PHASES
+
+            if matched and text:
+                if flag and (condition == 'first_visit' or once):
+                    await db_cog.set_flag(self.user_id, flag)
+                return text
+
+        return None
+
     async def back_to_town_callback(self, interaction: discord.Interaction):
         await interaction.response.defer()
         self.current_sub_location_id = None
@@ -1032,7 +1161,6 @@ class TownView(discord.ui.View):
 
         await db_cog.update_player(self.user_id, **update_kwargs)
 
-        from cogs.views.wilds import WildsView
 
         if destination_id in TOWNS:
             if dest_data.get('is_wilds'):
@@ -1140,7 +1268,22 @@ class TownView(discord.ui.View):
 
     async def shop_callback(self, interaction: discord.Interaction):
         await interaction.response.defer(ephemeral=True)
+        db_cog = self.bot.get_cog('Database')
+        player_data = await db_cog.get_player(self.user_id)
+        time_of_day = player_data.get('day_of_cycle', 'morning') if player_data else 'morning'
+        is_night = time_of_day in self._NIGHT_PHASES
+
         location_info = TOWNS.get(self.town_id, {}).get('locations', {}).get(self.current_sub_location_id, {})
+        services = location_info.get('services', {})
+
+        # Resolve time-aware item list
+        if is_night and 'shop_items_night' in services:
+            items_for_sale = services['shop_items_night']
+        else:
+            items_for_sale = services.get('shop_items', services.get('items_for_sale', []))
+
+        location_info = {**location_info, 'items_for_sale': items_for_sale}
+
         shop_view = ShopView(self.bot, self.user_id, self.parent_interaction, location_info)
         await shop_view.rebuild_ui()
         embed = await shop_view.build_embed()

--- a/data/explore_events.py
+++ b/data/explore_events.py
@@ -244,6 +244,153 @@ EXPLORE_EVENTS = {
             ],
         },
     ],
+
+    # ─────────────────────────────────────────────
+    # Mirefields — The Mire Path
+    # ─────────────────────────────────────────────
+    "mirefields": [
+
+        # --- Flavor Events ---
+        {
+            "type": "flavor",
+            "weight": 10,
+            "text": (
+                "The path disappears under two inches of brown water. You can't tell if it "
+                "continues forward or if you've already stepped off it."
+            ),
+        },
+        {
+            "type": "flavor",
+            "weight": 9,
+            "text": (
+                "A territorial bog creature bursts from the reeds, takes one look at you "
+                "and your pet, and retreats. You're bigger than its usual targets. Barely."
+            ),
+        },
+        {
+            "type": "flavor",
+            "weight": 8,
+            "text": (
+                "The ruins of a signpost poke out of the muck — three arrows pointing "
+                "different directions. None of the place names are legible. Someone has "
+                "tried to scratch new ones in. You can't read those either."
+            ),
+        },
+        {
+            "type": "flavor",
+            "weight": 8,
+            "text": (
+                "Sable's trail markers — knotted reed bundles tied to stakes — are the "
+                "only reliable guide here. You spot one and orient yourself. Without "
+                "these, you'd be walking in circles."
+            ),
+        },
+        {
+            "type": "flavor",
+            "weight": 5,
+            "text": (
+                "The fog sits low and still. Sound travels oddly — a splash from somewhere "
+                "to your left sounds close, then far, then close again. Nothing surfaces."
+            ),
+            "time": "night",
+        },
+
+        # --- Pet Sightings ---
+        {
+            "type": "pet_sighting",
+            "weight": 8,
+            "text": (
+                "A Murkback watches you from a half-submerged log, perfectly still. "
+                "It's not interested in fighting. It's waiting for you to leave its territory."
+            ),
+        },
+        {
+            "type": "pet_sighting",
+            "weight": 6,
+            "text": (
+                "Something moves under the surface in the deeper section of the mire. "
+                "Not small. It tracks alongside you for about a minute, then veers off "
+                "without surfacing."
+            ),
+        },
+        {
+            "type": "pet_sighting",
+            "weight": 5,
+            "text": (
+                "A Pallefin skims the surface of a still pool just off the path — barely "
+                "disturbing the water. It's gone before you can focus on it."
+            ),
+            "time": "day",
+        },
+        {
+            "type": "pet_sighting",
+            "weight": 5,
+            "text": (
+                "Something low and slow moves through the reeds. You can't see it clearly. "
+                "Just the reeds parting and settling. It doesn't come closer."
+            ),
+            "time": "night",
+        },
+
+        # --- Hazard Events ---
+        {
+            "type": "hazard",
+            "weight": 7,
+            "text": (
+                "You sink into a soft patch up to your knee. Extracting yourself takes "
+                "time and costs you. Your pet watches from dry ground with no sympathy."
+            ),
+            "outcome": {"energy": -1},
+        },
+        {
+            "type": "hazard",
+            "weight": 6,
+            "text": (
+                "A bog creature you didn't see charges from the shallow water — a glancing "
+                "hit. It was more startled than aggressive, but that doesn't help your ribs much."
+            ),
+            "outcome": {"hp": -10},
+        },
+
+        # --- Loot Bonus ---
+        {
+            "type": "loot_bonus",
+            "weight": 6,
+            "text": (
+                "You spot a waterlogged pack half-buried in the reed bed — old, probably "
+                "from the waystation days. Still has something inside worth keeping."
+            ),
+            "outcome": {"item": {"item_id": "zone_loot", "qty": 1}},
+        },
+
+        # --- Choice Events ---
+        {
+            "type": "choice",
+            "weight": 7,
+            "text": (
+                "A section of the old crossroads road is visible just beneath the water — "
+                "stone paving, still intact. You could follow it deeper into the mire, "
+                "or stick to Sable's markers."
+            ),
+            "choices": [
+                {
+                    "label": "Follow the old road",
+                    "emoji": "🗺️",
+                    "text": (
+                        "The paving holds for a while. Then it doesn't. You backtrack "
+                        "before it gets worse — but not before finding something."
+                    ),
+                    "outcome": {"item": {"item_id": "zone_loot", "qty": 1}, "energy": -1},
+                },
+                {
+                    "label": "Stick to the markers",
+                    "emoji": "🌿",
+                    "text": "Smart. You follow Sable's reeds and stay dry. Nothing happens.",
+                    "outcome": {},
+                },
+            ],
+        },
+    ],
 }
 
 
@@ -266,6 +413,12 @@ ZONE_LOOT_TABLES = {
         ("sun_kissed_berries", 4),
         ("trail_morsels",      2),
         ("moss_balm",          1),
+    ],
+    "mirefields": [
+        ("trail_morsels",    4),
+        ("mire_balm",        3),
+        ("bog_reed_bundle",  3),
+        ("tether_orb",       1),
     ],
     # Whisperwood and beyond added here when towns are built
 }

--- a/data/items.py
+++ b/data/items.py
@@ -23,6 +23,16 @@ ITEMS = {
         "effect": {"type": "heal_pet", "value": 20},
         "actions": ["use", "drop", "inspect"]
     },
+    "mire_balm": {
+        "name": "Mire Balm",
+        "description": "A compress made from bog herbs. Slightly less potent than Moss Balm, but Sable always has it in stock. Heals for 15 HP.",
+        "dropdown_description": "Heals your pet.",
+        "menu_description": "Heals your pet for 15 HP. A Mirefields staple.",
+        "category": "Consumables",
+        "price": 15,
+        "effect": {"type": "heal_pet", "value": 15},
+        "actions": ["use", "drop", "inspect"]
+    },
     "sun_kissed_berries": {
         "name": "Sun-Kissed Berries",
         "description": "Sweet berries that restore 25 player energy.",
@@ -46,6 +56,33 @@ ITEMS = {
     },
 
     # Crafting Materials
+    "bog_reed_bundle": {
+        "name": "Bog Reed Bundle",
+        "description": "Dense dried reeds from the Mirefields, bound tight. No use yet — but something this sturdy probably has one.",
+        "dropdown_description": "Crafting material.",
+        "menu_description": "Dense Mirefields reeds. Future crafting use.",
+        "category": "Crafting Materials",
+        "price": 8,
+        "actions": ["drop", "inspect"],
+    },
+    "murk_fragment": {
+        "name": "Murk Fragment",
+        "description": "A shard of mud-rock plating that flakes off a Murkback or Murkwall naturally. Dense and oddly smooth on one side.",
+        "dropdown_description": "Crafting material from Murkback.",
+        "menu_description": "Shed plating from a Murkback or Murkwall. Future crafting use.",
+        "category": "Crafting Materials",
+        "price": 12,
+        "actions": ["drop", "inspect"],
+    },
+    "pallefin_scale": {
+        "name": "Pallefin Scale",
+        "description": "A translucent, faintly luminescent scale shed by a Pallefin or Shimmerdeep. Rare. Catches light in a way that doesn't quite make sense.",
+        "dropdown_description": "Rare crafting material from Pallefin.",
+        "menu_description": "A rare luminescent scale. Future crafting use.",
+        "category": "Crafting Materials",
+        "price": 35,
+        "actions": ["drop", "inspect"],
+    },
     "mana_stone": {
         "name": "Mana Stone",
         "description": "A crystal humming with raw magical energy. Used to craft powerful artifacts.",
@@ -354,5 +391,30 @@ ITEMS = {
             "type": "restore_hunger",
             "value": 30
         }
-    }
+    },
+
+    # Lore Items
+    "waystation_ledger": {
+        "name": "Waystation Ledger",
+        "description": (
+            "Trader records from the Mirefields crossroads, back when it was still active. "
+            "Cargo manifests, names, dates — a place that mattered to people. "
+            "The last entry cuts off mid-sentence. The ink is still dry."
+        ),
+        "dropdown_description": "Lore item from the Old Crossroads.",
+        "menu_description": "Records from the Mirefields waystation. Read to learn its history.",
+        "category": "Lore Items",
+        "price": 0,
+        "actions": ["inspect", "drop"],
+        "lore_text": (
+            "**Waystation Ledger — Final Entries**\n\n"
+            "The records are methodical until the last few pages. Cargo in, cargo out. "
+            "Names of traders, quantities, dates. A place that worked.\n\n"
+            "The second-to-last entry notes a \"territorial disturbance near the south "
+            "foundation\" and a recommendation to reroute the eastern path.\n\n"
+            "The last entry is dated two weeks later. It reads: *\"Something has moved into "
+            "the ruins. Orin says leave it. Vessan says we can drive it out if we —\"*\n\n"
+            "It stops there."
+        ),
+    },
 }

--- a/data/pets.py
+++ b/data/pets.py
@@ -483,6 +483,176 @@ PET_DATABASE = {
             }
         }
     },
+
+    # -------------------------------------------------------------------------
+    # Mirefields
+    # -------------------------------------------------------------------------
+
+    "Murkback": {
+        "species": "Murkback", "pet_type": ["Water", "Ground"], "rarity": "Common",
+        "personality": "Defensive",
+        "description": (
+            "A squat, wide-bodied amphibian armored with a crust of dried mud and silt. "
+            "Slow on land, fast in shallow water. Territorial — it won't attack unless "
+            "you've stepped into its space, and then it won't stop."
+        ),
+        "base_capture_rate": 40,
+        "passive_ability": {
+            "name": "Bog Anchor",
+            "description": "Resistant to speed debuffs. Reduced knockback from all sources.",
+        },
+        "base_stat_ranges": {
+            "hp": [48, 54], "attack": [35, 40], "defense": [52, 58],
+            "special_attack": [22, 27], "special_defense": [45, 50], "speed": [18, 23],
+        },
+        "growth_rates": {
+            "hp": 2.0, "attack": 1.4, "defense": 2.4, "special_attack": 0.9,
+            "special_defense": 1.8, "speed": 0.8,
+        },
+        "skill_tree": {
+            "1": ["pound", "mud_slap"],
+            "6": ["water_pulse"],
+            "12": {"choice": ["iron_defense", "muddy_water"]},
+        },
+        "evolutions": {
+            "Murkwall": {
+                "evolves_at": 15,
+                "species": "Murkwall", "pet_type": ["Water", "Ground"], "rarity": "Uncommon",
+                "description": (
+                    "Larger, slower, and nearly immovable. The hide has thickened into "
+                    "layered mud-rock plating. Murkback's territorial instinct has become "
+                    "something quieter — it doesn't need to threaten. Everything else "
+                    "in the mire already knows to give it room."
+                ),
+                "base_stat_ranges": {
+                    "hp": [72, 78], "attack": [52, 58], "defense": [82, 88],
+                    "special_attack": [30, 36], "special_defense": [68, 74], "speed": [14, 19],
+                },
+                "growth_rates": {
+                    "hp": 2.4, "attack": 1.8, "defense": 2.8, "special_attack": 1.0,
+                    "special_defense": 2.2, "speed": 0.7,
+                },
+                "skill_tree": {
+                    "16": ["rock_wall"],
+                    "20": ["body_slam"],
+                    "25": {"choice": ["fortress_stance", "tidal_crush"]},
+                    "32": ["unyielding_focus"],
+                },
+            },
+        },
+    },
+
+    "Pallefin": {
+        "species": "Pallefin", "pet_type": "Water", "rarity": "Uncommon",
+        "personality": "Timid",
+        "description": (
+            "A small, almost translucent creature that skims the water surface without "
+            "disturbing it. Disappears into mist when startled. Unusually sensitive to "
+            "pressure and temperature — it reacts to changes in the environment before "
+            "any instrument does."
+        ),
+        "base_capture_rate": 28,
+        "passive_ability": {
+            "name": "Mist Veil",
+            "description": "Small evasion chance in fog or night conditions.",
+        },
+        "base_stat_ranges": {
+            "hp": [30, 35], "attack": [20, 25], "defense": [22, 27],
+            "special_attack": [45, 51], "special_defense": [38, 44], "speed": [50, 56],
+        },
+        "growth_rates": {
+            "hp": 1.4, "attack": 0.9, "defense": 1.0, "special_attack": 2.0,
+            "special_defense": 1.6, "speed": 2.2,
+        },
+        "skill_tree": {
+            "1": ["bubble", "swift"],
+            "7": ["mist"],
+            "13": {"choice": ["aqua_jet", "confuse_ray"]},
+        },
+        "evolutions": {
+            "Shimmerdeep": {
+                "evolves_at": 16,
+                "species": "Shimmerdeep", "pet_type": "Water", "rarity": "Rare",
+                "description": (
+                    "No longer skims the surface — descends. The translucency becomes "
+                    "a faint bioluminescence, generating soft light in dark water. "
+                    "Less ghost-like, more defined. Still environmentally sensitive, "
+                    "but now it draws attention to changes rather than fleeing from them."
+                ),
+                "base_stat_ranges": {
+                    "hp": [48, 54], "attack": [32, 38], "defense": [36, 42],
+                    "special_attack": [68, 74], "special_defense": [58, 64], "speed": [65, 71],
+                },
+                "growth_rates": {
+                    "hp": 1.8, "attack": 1.2, "defense": 1.4, "special_attack": 2.4,
+                    "special_defense": 2.0, "speed": 2.6,
+                },
+                "skill_tree": {
+                    "17": ["water_pulse"],
+                    "22": ["aurora_beam"],
+                    "27": {"choice": ["deep_current", "flash"]},
+                    "34": ["hydro_pump"],
+                },
+            },
+        },
+    },
+
+    "Siltborn": {
+        "species": "Siltborn", "pet_type": ["Poison", "Grass"], "rarity": "Rare",
+        "personality": "Aggressive",
+        "is_gloom_touched": False,
+        "description": (
+            "A roughly creature-shaped mass of compressed reeds, root tangles, and dark "
+            "silt. Low to the ground, slow, nearly indistinguishable from the bog floor "
+            "until it moves. Not Gloom-touched — the mire's wrongness is ancient and "
+            "organic. Ancient-feeling even as a young specimen. Night only."
+        ),
+        "base_capture_rate": 18,
+        "passive_ability": {
+            "name": "Reclaim",
+            "description": "Recovers a small amount of HP at the end of each turn. The bog sustains it.",
+        },
+        "base_stat_ranges": {
+            "hp": [55, 61], "attack": [48, 54], "defense": [44, 50],
+            "special_attack": [36, 42], "special_defense": [40, 46], "speed": [16, 21],
+        },
+        "growth_rates": {
+            "hp": 2.2, "attack": 2.0, "defense": 1.8, "special_attack": 1.4,
+            "special_defense": 1.6, "speed": 0.8,
+        },
+        "skill_tree": {
+            "1": ["pound", "poison_sting"],
+            "8": ["vine_whip"],
+            "14": {"choice": ["toxic", "leech_seed"]},
+        },
+        "evolutions": {
+            "Mirewarden": {
+                "evolves_at": 18,
+                "species": "Mirewarden", "pet_type": ["Poison", "Grass"], "rarity": "Very Rare",
+                "is_gloom_touched": False,
+                "description": (
+                    "Larger, denser. Reeds and roots have grown through it, not just "
+                    "coating it. Moves slower but hits like the terrain itself shifted. "
+                    "No longer blends in — looks like a landmark that happens to move. "
+                    "The Old Crossroads Mirewarden is implied to be beyond even this stage."
+                ),
+                "base_stat_ranges": {
+                    "hp": [82, 88], "attack": [72, 78], "defense": [66, 72],
+                    "special_attack": [50, 56], "special_defense": [60, 66], "speed": [12, 17],
+                },
+                "growth_rates": {
+                    "hp": 2.6, "attack": 2.4, "defense": 2.2, "special_attack": 1.6,
+                    "special_defense": 2.0, "speed": 0.7,
+                },
+                "skill_tree": {
+                    "19": ["poison_fang"],
+                    "24": ["power_whip"],
+                    "29": {"choice": ["toxic_spikes", "sludge_bomb"]},
+                    "36": ["overwhelm"],
+                },
+            },
+        },
+    },
 }
 
 # =================================================================================
@@ -530,5 +700,9 @@ ENCOUNTER_TABLES = {
     "whisperwoodGrove": {
         "day": ["Mossling", "Sunpetal Moth"],
         "night": ["Mossling", "Gloom Weaver", "Moonpetal Sprite"]
-    }
+    },
+    "mirefields": {
+        "day": ["Murkback", "Pallefin", "Mossling", "Corroder"],
+        "night": ["Murkback", "Gloom Weaver", "Siltborn", "Corroder"],
+    },
 }

--- a/data/remnants.py
+++ b/data/remnants.py
@@ -259,6 +259,24 @@ REMNANTS = {
                     "The trail is nearly invisible in the dark. Every sound is amplified. "
                     "Moving through here at night requires patience and a steady pet."
                 ),
+                "on_enter": [
+                    {
+                        "condition": "first_visit",
+                        "flag": "visited_bogside_trail",
+                        "text": (
+                            "The path disappears under two inches of brown water. "
+                            "You can't tell if it continues forward or if you've already stepped off it. "
+                            "Somewhere to your left, something shifts in the reeds."
+                        ),
+                    },
+                    {
+                        "condition": "time:night",
+                        "once": False,
+                        "text": (
+                            "*The fog is worse at night. You knew that before you came out here.*"
+                        ),
+                    },
+                ],
                 "services": {
                     "explore_zone": "mirefields",
                     "gloom_level": 8,
@@ -274,15 +292,47 @@ REMNANTS = {
                 "description_day": (
                     "A compact camp built from salvaged wood and waterproofed canvas. "
                     "Traps and pelts hang from a line. Sable runs a lean operation — "
-                    "everything here has a purpose."
+                    "everything here has a purpose. A large armored creature rests on "
+                    "a flat rock near the water's edge, motionless."
                 ),
                 "description_night": (
                     "The camp lantern is on. Sable keeps late hours. "
-                    "Half the road traffic passes through at night, and she knows it."
+                    "The armored creature on the flat rock hasn't moved. "
+                    "You're not sure it's sleeping."
                 ),
+                "on_enter": [
+                    {
+                        "condition": "first_visit",
+                        "flag": "visited_sables_post",
+                        "text": (
+                            "Sable glances up from her work. *\"You lost? Most people "
+                            "don't come through here by choice. I've got supplies — "
+                            "nothing fancy, but it'll keep you alive.\"*"
+                        ),
+                    },
+                    {
+                        "condition": "has_pet_species:Murkback",
+                        "once": True,
+                        "flag": "sable_murkback_reaction_seen",
+                        "text": (
+                            "Sable's eyes drop to your pet for a moment. "
+                            "*\"Caught one of those, did you. Give it time.\"* "
+                            "She doesn't elaborate."
+                        ),
+                    },
+                    {
+                        "condition": "time:night",
+                        "once": False,
+                        "text": (
+                            "*\"You're braver than most, traveling through here at night. "
+                            "Or dumber. Hard to tell.\"*"
+                        ),
+                    },
+                ],
                 "services": {
                     "shop": True,
-                    "shop_items": ["moss_balm", "trail_morsels", "tether_orb"],
+                    "shop_items": ["mire_balm", "trail_morsels", "tether_orb", "bog_reed_bundle", "murk_fragment"],
+                    "shop_items_night": ["trail_morsels", "tether_orb", "bog_reed_bundle", "murk_fragment"],  # mire_balm out of stock at night
                     "rest": {
                         "type": "rough_camp",
                         "cost": 0,
@@ -301,6 +351,22 @@ REMNANTS = {
                         "role": "Bog Trapper",
                         "emoji": "🪤",
                         "availability": "all",
+                        "pet": {
+                            "species": "murkwall",
+                            "nickname": "ledge",
+                            "nickname_visible_flag": "sable_ledge_name_revealed",
+                            "description": (
+                                "A large armored creature rests on a flat rock near the "
+                                "water's edge. It doesn't patrol. It just exists there. "
+                                "Everything else in the mire has done the math."
+                            ),
+                            "player_species_reactions": {
+                                "Murkback": (
+                                    "*\"Caught one of those, did you. Give it time.\"* "
+                                    "She doesn't elaborate."
+                                ),
+                            },
+                        },
                         "dialogue": {
                             "default": (
                                 "You lost? Most people don't come through here by choice. "
@@ -312,9 +378,158 @@ REMNANTS = {
                                 "Or dumber. Hard to tell. Watch your step — the mire shifts after dark."
                             ),
                             "sell": "Take what you need and move on. I don't do small talk.",
+                            "lore_crossroads": (
+                                "Used to be busy. Road ran right through — traders, couriers, "
+                                "a waystation that served maybe thirty people a day. Then one wet "
+                                "season the mire came up and didn't stop. "
+                                "*\"Not everything's meant to last.\"*"
+                            ),
+                            "lore_ferryn": (
+                                "*\"She's going to measure every reed in this bog and go home "
+                                "with a headache.\"* No malice in it. She just knows how this ends."
+                            ),
+                            "lore_deep_mire": (
+                                "*\"Nothing worth finding out there.\"*"
+                            ),
+                            "returning_player": (
+                                "She recognizes you. Doesn't say anything about it. "
+                                "Just sets out the usual without being asked."
+                            ),
                         },
                     },
                 },
+            },
+
+            "reed_hollow": {
+                "name": "The Reed Hollow",
+                "emoji": "🌿",
+                "menu_description": "A naturalist's camp in the reeds. Someone is studying the mire.",
+                "availability": "all",
+                # TODO: seasonal logic — Ferryn is gone at higher rank/story flag.
+                # When absent: show her field notes instead of NPC. Wire when quest line is ready.
+                "description_day": (
+                    "A tidy research camp tucked into a bend in the reeds. Charts and "
+                    "specimen jars line a folding table. A small creature is perched on "
+                    "the edge of a water sample jar, watching it intently."
+                ),
+                "description_night": (
+                    "A lantern burns low over the research table. Notes are spread across "
+                    "it, weighted down against the breeze. She works late."
+                ),
+                "on_enter": [
+                    {
+                        "condition": "first_visit",
+                        "flag": "visited_reed_hollow",
+                        "text": (
+                            "A young woman looks up from her instruments with immediate "
+                            "curiosity. *\"Oh — a traveler. Perfect timing, actually. "
+                            "Have you noticed anything unusual on the Bogside Trail? "
+                            "Unusual even for here, I mean.\"*"
+                        ),
+                    },
+                    {
+                        "condition": "has_pet_species:Pallefin",
+                        "once": True,
+                        "flag": "ferryn_pallefin_reaction_seen",
+                        "text": (
+                            "Ferryn's eyes go wide. *\"Is that — that's a Pallefin. "
+                            "Where did you find it? I've only seen Silt behave like that "
+                            "near the crossroads boundary — does yours do that too?\"* "
+                            "She's already reaching for her notes."
+                        ),
+                    },
+                ],
+                "npcs": {
+                    "ferryn": {
+                        "name": "Ferryn",
+                        "role": "Field Naturalist",
+                        "emoji": "🌿",
+                        "availability": "all",
+                        "pet": {
+                            "species": "pallefin",
+                            "nickname": "silt",
+                            "nickname_visible_flag": None,  # Ferryn tells everyone immediately
+                            "description": (
+                                "A small, almost translucent creature perches on the rim "
+                                "of a water sample jar, watching the surface intently. "
+                                "Ferryn named it on the first day. She will tell you this "
+                                "story whether you ask or not."
+                            ),
+                            "player_species_reactions": {
+                                "Pallefin": (
+                                    "*\"You have one too! I named mine Silt — it was in "
+                                    "the silt, it seemed right. What's yours called?\"*"
+                                ),
+                            },
+                        },
+                        "dialogue": {
+                            "default": (
+                                "Oh — yes, hello. I'm cataloguing the bog expansion. "
+                                "The mire is growing faster than natural rates should allow. "
+                                "Something is accelerating it. I don't know what yet, "
+                                "but the instruments point toward the Old Crossroads."
+                            ),
+                            "about_sable": (
+                                "*\"She knows this place better than anyone. She just "
+                                "doesn't seem curious about why it is the way it is.\"* "
+                                "A pause. *\"She told me not to go near the crossroads. "
+                                "I'm... taking that under advisement.\"*"
+                            ),
+                            "lore_expansion": (
+                                "The growth rate is wrong. Bog expansion is measurable — "
+                                "predictable, even. This isn't that. Something here is "
+                                "feeding it. My instruments read differently near the "
+                                "Old Crossroads than anywhere else in the mire."
+                            ),
+                            "lore_crossroads": (
+                                "*\"I want to document it properly. Get close, take "
+                                "readings. Sable says not to. She didn't explain why — "
+                                "just 'not to.' I've noted it as a local superstition "
+                                "for now, but...\"* She trails off, glancing toward the fog."
+                            ),
+                        },
+                    },
+                },
+            },
+
+            "old_crossroads": {
+                "name": "The Old Crossroads",
+                "emoji": "🪨",
+                "menu_description": "Ruins of a waystation, half-swallowed by the mire.",
+                "availability": "all",
+                "description_day": (
+                    "The stone foundations of the old waystation are still visible — "
+                    "half-submerged, overgrown with dark reeds. The signpost still stands. "
+                    "Three arrows, all pointing different directions. No legible names. "
+                    "Something has been dragging through here. Recently. "
+                    "There is an unnatural stillness to this part of the mire."
+                ),
+                "description_night": (
+                    "The ruins are barely visible in the fog. The signpost casts a long "
+                    "shadow in the lantern light. You have the distinct sense that "
+                    "something here is aware of you. Not hostile. Just aware."
+                ),
+                "on_enter": [
+                    {
+                        "condition": "first_visit",
+                        "flag": "visited_old_crossroads",
+                        "text": (
+                            "The air here is different. Heavier. Your pet moves closer "
+                            "to you without being told."
+                        ),
+                    },
+                    {
+                        "condition": "time:night",
+                        "once": False,
+                        "text": (
+                            "*You came here at night. That was your choice.*"
+                        ),
+                    },
+                ],
+                # TODO: Choice event (take the ledger) — wire when quest lines are ready.
+                # The Mirewarden territory interaction is lore only for now.
+                "services": {},
+                "npcs": {},
             },
         },
     },


### PR DESCRIPTION
## Summary
- **on_enter system** — ephemeral auto-dialogue fires when entering any sub-location. Conditions: `first_visit`, `has_pet_species`, `flag`, `no_flag`, `time:day/night`, `once` flag support. Wired in both `TownView` and `RemnantView`.
- **Mirefields fully built** — Bogside Trail (explore), Sable's Post (shop + rest + NPC), Reed Hollow (Ferryn), Old Crossroads (lore stub, quest-tagged)
- **Sable** — full dialogue variants, pet field (Ledge/Murkwall, nickname hidden behind flag), on_enter (first visit greeting, Murkback reaction, night line)
- **Ferryn** — full NPC entry + dialogue, pet field (Silt/Pallefin, nickname public), on_enter (first visit, Pallefin reaction)
- **Night shop variant** — `shop_items_night` wired in both shop callbacks; Sable's `mire_balm` drops off shelf at night
- **New pets** — Murkback→Murkwall, Pallefin→Shimmerdeep, Siltborn→Mirewarden with stats, passives, skill trees. Siltborn `is_gloom_touched: False`
- **Mirefields encounter table** — day/night
- **New items** — `mire_balm`, `bog_reed_bundle`, `murk_fragment`, `pallefin_scale`, `waystation_ledger` (with lore text)
- **Explore events** — 10 events for `mirefields` zone; explore system now filters event pool by time of day before random selection
- **TownView layout fix** — both dropdowns now adjacent, Explore Wilds button moves below travel dropdown
- **🔍 emoji** added to RemnantView explore placeholder
- **Bug fixes** — `ModuleNotFoundError: cogs.views.wilds` (WildsView is in towns.py), species casing in `on_enter` conditions matched to DB storage

## Test plan
- [ ] Enter Sable's Post for the first time — greeting fires as ephemeral
- [ ] Enter Sable's Post with a Murkback — reaction fires once, never again
- [ ] Enter Sable's Post at night — night line fires, mire_balm missing from shop
- [ ] Enter Reed Hollow — Ferryn intro fires
- [ ] Enter Reed Hollow with a Pallefin — Ferryn reacts
- [ ] Oakhaven Outpost: Explore dropdown and Travel dropdown are adjacent, Explore Wilds below
- [ ] Travel from a town — no ModuleNotFoundError
- [ ] Explore Mirefields — time-gated events (night-only) don't fire during day

🤖 Generated with [Claude Code](https://claude.com/claude-code)