### PR TITLE
Weeping Chasm foundation + pet renames + Ancient rarity

### DIFF
--- a/data/explore_events.py
+++ b/data/explore_events.py
@@ -246,6 +246,185 @@ EXPLORE_EVENTS = {
     ],
 
     # ─────────────────────────────────────────────
+    # Weeping Chasm — The Chasm's Edge
+    # ─────────────────────────────────────────────
+    "weeping_chasm": [
+
+        # --- Flavor Events ---
+        {
+            "type": "flavor",
+            "weight": 10,
+            "text": (
+                "The chasm exhales cold air in a slow, rhythmic pulse. "
+                "Your pet refuses to approach the edge. "
+                "It doesn't move until the pulse stops."
+            ),
+        },
+        {
+            "type": "flavor",
+            "weight": 9,
+            "text": (
+                "A Guild marker post — cracked, the rune barely holding. "
+                "Someone scratched a tally into the wood. Thirty-seven marks. "
+                "You don't know what they were counting."
+            ),
+        },
+        {
+            "type": "flavor",
+            "weight": 8,
+            "text": (
+                "A sound rises from below. Not a creature — more like a voice, "
+                "too deep and too slow to understand. "
+                "It stops the moment you move."
+            ),
+        },
+        {
+            "type": "flavor",
+            "weight": 7,
+            "text": (
+                "Near the Whispering Stones — a cluster of rounded rocks at the "
+                "sealed section — the air hums faintly. Guild records say this is "
+                "where the first ward was placed. Whatever it was holding, it's still holding."
+            ),
+        },
+        {
+            "type": "flavor",
+            "weight": 6,
+            "text": (
+                "The mist curls upward around your ankles. "
+                "Nothing attacks. Something is just checking.",
+            ),
+            "time": "night",
+        },
+        {
+            "type": "flavor",
+            "weight": 5,
+            "text": (
+                "The breathing from below changes rhythm. Slower. Deeper. "
+                "Your pet goes completely still and won't move until it resumes."
+            ),
+            "time": "night",
+        },
+
+        # --- Pet Sightings ---
+        {
+            "type": "pet_sighting",
+            "weight": 8,
+            "text": (
+                "A Corroder sits at the chasm's lip, staring down into the dark "
+                "instead of at you. It doesn't react to your presence. "
+                "It seems drawn to the source."
+            ),
+        },
+        {
+            "type": "pet_sighting",
+            "weight": 6,
+            "text": (
+                "Something pale drifts upward from the chasm on the cold thermal — "
+                "translucent, barely there, gone before you can focus on it."
+            ),
+        },
+        {
+            "type": "pet_sighting",
+            "weight": 5,
+            "text": (
+                "The east wall of the Chasm is covered in thick, dark silk from rim "
+                "to rock face. Something enormous spun this overnight. "
+                "The webbing is still faintly warm."
+            ),
+        },
+
+        # --- Hazard Events ---
+        {
+            "type": "hazard",
+            "weight": 7,
+            "text": (
+                "A cold updraft hits without warning — disorienting, wrong. "
+                "Not wind. An exhale from below. Your pet stumbles. You catch it."
+            ),
+            "outcome": {"hp": -8},
+        },
+        {
+            "type": "hazard",
+            "weight": 6,
+            "text": (
+                "The ground near the Tainted Ledge shifts. A crack opens, "
+                "runs three feet, stops. You step back slowly. "
+                "The crack doesn't close."
+            ),
+            "outcome": {"energy": -1},
+        },
+
+        # --- Loot Bonus ---
+        {
+            "type": "loot_bonus",
+            "weight": 5,
+            "text": (
+                "A Guild emergency cache bolted to a post near the sealed section. "
+                "Still stocked. Someone kept resupplying this long after the post was abandoned."
+            ),
+            "outcome": {"item": {"item_id": "zone_loot", "qty": 1}},
+        },
+
+        # --- Choice Events ---
+        {
+            "type": "choice",
+            "weight": 6,
+            "text": (
+                "A sealed Guild journal is wedged in a crack near the Tainted Ledge. "
+                "It's been here a while — the wax seal is intact but the cover is "
+                "warped from cold. You could pry it open."
+            ),
+            "choices": [
+                {
+                    "label": "Pry it open",
+                    "emoji": "📖",
+                    "text": (
+                        "The seal breaks. Inside: field notes, precise until the last few pages "
+                        "where the handwriting changes. You take the fragment. "
+                        "The Gloom around you feels slightly heavier."
+                    ),
+                    "outcome": {"item": {"item_id": "lore_fragment", "qty": 1}, "gloom_tick": 5},
+                },
+                {
+                    "label": "Leave it",
+                    "emoji": "🚶",
+                    "text": "Some things stay sealed for a reason. You walk away.",
+                    "outcome": {},
+                },
+            ],
+        },
+
+        # --- Apex Lore Events (Chasmbane + Veilmother) ---
+        # These are atmosphere/scare events — no battle, no capture.
+        # Full rank-gated encounter logic tagged for later.
+        {
+            "type": "hazard",
+            "weight": 3,
+            "text": (
+                "The mist stops. All of it — in an instant. The chasm goes completely "
+                "silent. Something at the rim of your vision, near the base of the wall, "
+                "is large enough that your mind refuses to measure it. "
+                "It isn't looking at you. Then it is. "
+                "The Gloom floods your senses before you consciously decide to back away."
+            ),
+            "outcome": {"gloom_tick": 15},
+        },
+        {
+            "type": "pet_sighting",
+            "weight": 2,
+            "time": "night",
+            "text": (
+                "The east wall moves. Not shifts — moves, deliberately, slowly. "
+                "A section of what you thought was webbing detaches from the rock face "
+                "and redistributes itself further up. The scale of it doesn't make sense "
+                "until you find a marker post for reference. "
+                "You stop using the marker post for reference."
+            ),
+        },
+    ],
+
+    # ─────────────────────────────────────────────
     # Mirefields — The Mire Path
     # ─────────────────────────────────────────────
     "mirefields": [
@@ -413,6 +592,11 @@ ZONE_LOOT_TABLES = {
         ("sun_kissed_berries", 4),
         ("trail_morsels",      2),
         ("moss_balm",          1),
+    ],
+    "weeping_chasm": [
+        ("moss_balm",     3),
+        ("tether_orb",    3),
+        ("trail_morsels", 2),
     ],
     "mirefields": [
         ("trail_morsels",    4),

--- a/data/items.py
+++ b/data/items.py
@@ -394,6 +394,38 @@ ITEMS = {
     },
 
     # Lore Items
+    "lore_fragment": {
+        "name": "Guild Record Fragment",
+        "description": (
+            "A page torn from a sealed Guild journal found near the Tainted Ledge. "
+            "The handwriting is steady until the last few lines, where it isn't."
+        ),
+        "dropdown_description": "Lore item from the Weeping Chasm.",
+        "menu_description": "A fragment from a sealed Guild journal. Read to learn what it contained.",
+        "category": "Lore Items",
+        "price": 0,
+        "actions": ["inspect", "drop"],
+        "lore_text": (
+            "**Guild Field Record — Warden Post Attachment**\n\n"
+            "The handwriting is precise for the first half — dates, creature sightings, "
+            "patrol notes. Standard warden documentation.\n\n"
+            "Near the bottom the writing changes. Faster. Less careful.\n\n"
+            "*'The mist tonight came up from the chasm in a single column. Not diffuse — "
+            "directed. It moved toward the post. Stopped at the ward line. "
+            "I watched it for approximately four minutes.*\n\n"
+            "*It went back down.*\n\n"
+            "*I don't know what to put in the official report.'*"
+        ),
+    },
+    "gloom_mist_sample": {
+        "name": "Gloom-mist Sample",
+        "description": "A sealed vial of dense Gloom-mist collected from a hollow in the rock at the Chasm's Edge. The glass is cold to the touch.",
+        "dropdown_description": "Quest item — Kael's research.",
+        "menu_description": "A vial of Gloom-mist for Lore-Keeper Kael. Part of the echoes_from_below quest.",
+        "category": "Quest Items",
+        "price": 0,
+        "actions": ["inspect"],
+    },
     "waystation_ledger": {
         "name": "Waystation Ledger",
         "description": (

--- a/data/pets.py
+++ b/data/pets.py
@@ -236,9 +236,9 @@ PET_DATABASE = {
 
         # --- EVOLUTIONS ARE NOW NESTED ---
         "evolutions": {
-            "Sludge Shell": {
+            "Grimplate": {
                 "evolves_at": 15,
-                "species": "Sludge Shell", "pet_type": ["Rock", "Poison"], "rarity": "Uncommon",
+                "species": "Grimplate", "pet_type": ["Rock", "Poison"], "rarity": "Uncommon",
                 "description": "A larger, more heavily armored successor to the Corroder. Its shell has fused into dense, layered rock, and the toxic sludge it secretes has thickened into a viscous, slow-dripping poison.",
                 "base_stat_ranges": {"hp": [60, 65], "attack": [45, 50], "defense": [70, 75],
                                      "special_attack": [35, 40],
@@ -252,9 +252,9 @@ PET_DATABASE = {
                     "25": ["miasmal_aura"]
                 },
                 "evolutions": {
-                    "Ossuary Golem": {
+                    "Blightcrust": {
                         "evolves_at": 30,
-                        "species": "Ossuary Golem", "pet_type": ["Rock", "Poison"], "rarity": "Rare",
+                        "species": "Blightcrust", "pet_type": ["Rock", "Poison"], "rarity": "Rare",
                         "description": "A towering construct of fused bones and hardened sludge, shaped by years of Gloom exposure into something ancient and terrifying. It moves slowly but radiates an aura of decay that withers anything that lingers too close.",
                         "base_stat_ranges": {"hp": [80, 85], "attack": [70, 75], "defense": [110, 115],
                                              "special_attack": [50, 55],
@@ -391,8 +391,8 @@ PET_DATABASE = {
         }
     },
 
-    "Gloom Weaver": {
-        "species": "Gloom Weaver",
+    "Grimweave": {
+        "species": "Grimweave",
         "pet_type": ["Ghost", "Poison"],
         "rarity": "Uncommon",
         "personality": "Aggressive",
@@ -414,9 +414,9 @@ PET_DATABASE = {
             "14": {"choice": ["umbral_shift", "grudge"]}
         },
         "evolutions": {
-            "Dreadspinner": {
+            "Duskspinner": {
                 "evolves_at": 16,
-                "species": "Dreadspinner",
+                "species": "Duskspinner",
                 "pet_type": ["Ghost", "Poison"],
                 "rarity": "Rare",
                 "description": "A larger, more terrifying form that wraps itself in a shroud of writhing Gloom-silk. Its eight limbs move with unsettling precision, and the webs it spins can trap both body and spirit.",
@@ -433,6 +433,36 @@ PET_DATABASE = {
                     "22": ["caustic_venom"],
                     "27": {"choice": ["sludge_bomb", "venomous_erosion"]},
                     "32": ["soulrend"]
+                },
+                "evolutions": {
+                    "Veilmother": {
+                        "evolves_at": 30,
+                        "species": "Veilmother",
+                        "pet_type": ["Ghost", "Poison"],
+                        "rarity": "Ancient",
+                        "is_gloom_touched": True,
+                        "description": (
+                            "The final form of the Grimweave line. Lives on the east wall face "
+                            "of the Weeping Chasm, passive and vast. Doesn't hunt — waits. "
+                            "Everything that falls into the chasm finds its web. The east wall "
+                            "webbing is visible from the Chasm's Edge. Capturable only at "
+                            "Legend rank, theoretically."
+                        ),
+                        "base_capture_rate": 2,
+                        "passive_ability": {
+                            "name": "Endless Web",
+                            "description": "At battle start, the opponent's speed is reduced by 20% and cannot be increased.",
+                        },
+                        "base_stat_ranges": {"hp": [90, 96], "attack": [82, 88], "defense": [65, 71],
+                                             "special_attack": [105, 111], "special_defense": [78, 84], "speed": [70, 76]},
+                        "growth_rates": {"hp": 2.8, "attack": 2.6, "defense": 2.0, "special_attack": 3.2,
+                                         "special_defense": 2.4, "speed": 2.2},
+                        "skill_tree": {
+                            "32": ["soulrend"],
+                            "38": {"choice": ["umbral_shift", "venomous_erosion"]},
+                            "45": ["miasmal_aura"],
+                        },
+                    }
                 }
             }
         }
@@ -482,6 +512,183 @@ PET_DATABASE = {
                 }
             }
         }
+    },
+
+    # -------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
+    # Weeping Chasm
+    # -------------------------------------------------------------------------
+
+    "Gauntling": {
+        "species": "Gauntling", "pet_type": ["Ghost", "Normal"], "rarity": "Common",
+        "personality": "Timid",
+        "is_gloom_touched": True,
+        "description": (
+            "A creature that has lived too close to the Gloom source for generations. "
+            "Not violently corrupted — born already fading. Partially translucent, "
+            "slow-moving, like something losing its physical definition over time. "
+            "It isn't Hollowed yet. It's on the way there and doesn't know it."
+        ),
+        "base_capture_rate": 38,
+        "passive_ability": {
+            "name": "Fading Form",
+            "description": "Small chance to phase through incoming physical attacks.",
+        },
+        "base_stat_ranges": {
+            "hp": [35, 40], "attack": [25, 30], "defense": [20, 25],
+            "special_attack": [38, 43], "special_defense": [30, 35], "speed": [32, 37],
+        },
+        "growth_rates": {
+            "hp": 1.6, "attack": 1.2, "defense": 1.0, "special_attack": 1.8,
+            "special_defense": 1.4, "speed": 1.5,
+        },
+        "skill_tree": {
+            "1": ["pound", "confuse_ray"],
+            "6": ["mist"],
+            "11": {"choice": ["umbral_shift", "siphon_sorrow"]},
+        },
+        "evolutions": {
+            "Waneling": {
+                "evolves_at": 15,
+                "species": "Waneling", "pet_type": ["Ghost", "Normal"], "rarity": "Uncommon",
+                "is_gloom_touched": True,
+                "description": (
+                    "Further faded. More ghost than creature now. Barely there. "
+                    "Still moves. Still hunts. At this stage it barely registers on "
+                    "the eye — you sense it more than see it."
+                ),
+                "base_stat_ranges": {
+                    "hp": [50, 56], "attack": [38, 44], "defense": [30, 36],
+                    "special_attack": [58, 64], "special_defense": [46, 52], "speed": [50, 56],
+                },
+                "growth_rates": {
+                    "hp": 2.0, "attack": 1.6, "defense": 1.3, "special_attack": 2.2,
+                    "special_defense": 1.8, "speed": 1.9,
+                },
+                "skill_tree": {
+                    "16": ["grudge"],
+                    "21": ["soulrend"],
+                    "26": {"choice": ["umbral_shift", "precognition"]},
+                },
+            },
+        },
+    },
+
+    "Rimecrawl": {
+        "species": "Rimecrawl", "pet_type": ["Ice", "Poison"], "rarity": "Uncommon",
+        "personality": "Defensive",
+        "is_gloom_touched": True,
+        "description": (
+            "Moves along the chasm walls, slow and methodical. Leaves trails of "
+            "frost-laced Gloom residue. Where it passes, the stone gets colder. "
+            "You notice the trails before you notice the creature. "
+            "Patient. Creeping. Wrong in a quiet way."
+        ),
+        "base_capture_rate": 28,
+        "passive_ability": {
+            "name": "Cold Trail",
+            "description": "Leaves a frost residue on the field — minor damage and speed reduction to opponents who attack.",
+        },
+        "base_stat_ranges": {
+            "hp": [44, 50], "attack": [30, 36], "defense": [48, 54],
+            "special_attack": [42, 48], "special_defense": [44, 50], "speed": [18, 24],
+        },
+        "growth_rates": {
+            "hp": 1.9, "attack": 1.3, "defense": 2.1, "special_attack": 1.8,
+            "special_defense": 1.9, "speed": 0.9,
+        },
+        "skill_tree": {
+            "1": ["pound", "poison_sting"],
+            "7": ["harden"],
+            "13": {"choice": ["acid_armor", "venomous_haze"]},
+        },
+        "evolutions": {
+            "Frostbile": {
+                "evolves_at": 16,
+                "species": "Frostbile", "pet_type": ["Ice", "Poison"], "rarity": "Rare",
+                "is_gloom_touched": True,
+                "description": (
+                    "Larger, slower. The trail it leaves now crystallizes into something "
+                    "that damages anything walking through it. Turns the terrain into a weapon."
+                ),
+                "base_stat_ranges": {
+                    "hp": [65, 71], "attack": [46, 52], "defense": [72, 78],
+                    "special_attack": [62, 68], "special_defense": [66, 72], "speed": [14, 20],
+                },
+                "growth_rates": {
+                    "hp": 2.3, "attack": 1.7, "defense": 2.5, "special_attack": 2.2,
+                    "special_defense": 2.3, "speed": 0.8,
+                },
+                "skill_tree": {
+                    "17": ["miasmal_aura"],
+                    "23": ["caustic_venom"],
+                    "28": {"choice": ["venomous_erosion", "contagious_blight"]},
+                    "35": ["ossuary_aegis"],
+                },
+            },
+        },
+    },
+
+    "Threshling": {
+        "species": "Threshling", "pet_type": ["Dark", "Ghost"], "rarity": "Rare",
+        "personality": "Aggressive",
+        "is_gloom_touched": True,
+        "description": (
+            "Caught at the threshold between existence and full Gloom consumption. "
+            "Parts of it solid, parts of it mist. One eye clear, one eye dark. "
+            "Not fully Hollowed — locked in between states. "
+            "Gretta caught one at this exact moment and has held it there."
+        ),
+        "base_capture_rate": 12,
+        "passive_ability": {
+            "name": "Threshold",
+            "description": "Drains a small amount of the opponent's Gloom Meter passively each turn.",
+        },
+        "base_stat_ranges": {
+            "hp": [52, 58], "attack": [58, 64], "defense": [38, 44],
+            "special_attack": [55, 61], "special_defense": [42, 48], "speed": [44, 50],
+        },
+        "growth_rates": {
+            "hp": 2.1, "attack": 2.4, "defense": 1.6, "special_attack": 2.2,
+            "special_defense": 1.7, "speed": 1.8,
+        },
+        "skill_tree": {
+            "1": ["rotten_grasp", "grudge"],
+            "8": ["siphon_sorrow"],
+            "15": {"choice": ["umbral_shift", "soulrend"]},
+        },
+        "evolutions": {
+            "Threshbound": {
+                "evolves_at": 20,
+                "species": "Threshbound", "pet_type": ["Dark", "Ghost"], "rarity": "Ancient",
+                "is_gloom_touched": True,
+                "description": (
+                    "Has been held at the threshold so long it IS the threshold. "
+                    "Not because it grew larger, but because it became something that "
+                    "defies classification. Barely contained. Seeing one should feel "
+                    "like a warning. Gretta has one. Nobody else does."
+                ),
+                "base_capture_rate": 1,
+                "passive_ability": {
+                    "name": "Threshold Mastery",
+                    "description": "Drains the opponent's Gloom Meter each turn and converts it to HP.",
+                },
+                "base_stat_ranges": {
+                    "hp": [80, 86], "attack": [88, 94], "defense": [58, 64],
+                    "special_attack": [82, 88], "special_defense": [62, 68], "speed": [62, 68],
+                },
+                "growth_rates": {
+                    "hp": 2.5, "attack": 2.8, "defense": 2.0, "special_attack": 2.6,
+                    "special_defense": 2.1, "speed": 2.2,
+                },
+                "skill_tree": {
+                    "21": ["soulrend"],
+                    "26": ["umbral_shift"],
+                    "32": {"choice": ["grudge", "sorrowful_strike"]},
+                    "40": ["overwhelm"],
+                },
+            },
+        },
     },
 
     # -------------------------------------------------------------------------
@@ -699,10 +906,14 @@ ENCOUNTER_TABLES = {
     },
     "whisperwoodGrove": {
         "day": ["Mossling", "Sunpetal Moth"],
-        "night": ["Mossling", "Gloom Weaver", "Moonpetal Sprite"]
+        "night": ["Mossling", "Grimweave", "Moonpetal Sprite"]
     },
     "mirefields": {
         "day": ["Murkback", "Pallefin", "Mossling", "Corroder"],
-        "night": ["Murkback", "Gloom Weaver", "Siltborn", "Corroder"],
+        "night": ["Murkback", "Grimweave", "Siltborn", "Corroder"],
+    },
+    "weeping_chasm": {
+        "day": ["Gauntling", "Rimecrawl", "Corroder"],
+        "night": ["Gauntling", "Rimecrawl", "Grimweave", "Corroder", "Waneling", "Frostbile", "Grimplate", "Threshling"],
     },
 }

--- a/data/remnants.py
+++ b/data/remnants.py
@@ -68,6 +68,25 @@ REMNANTS = {
                     "The mist curls upward around your ankles. The darkness below is total. "
                     "Nothing attacks. Something is just checking."
                 ),
+                "on_enter": [
+                    {
+                        "condition": "first_visit",
+                        "flag": "visited_chasms_edge",
+                        "text": (
+                            "The cold hits before you reach the rim. Your pet stops a full "
+                            "step behind you and won't come closer. From below — not wind, "
+                            "not echo — something like breathing."
+                        ),
+                    },
+                    {
+                        "condition": "time:night",
+                        "once": False,
+                        "text": (
+                            "*The mist curls upward around your ankles. "
+                            "Nothing attacks. Something is just checking.*"
+                        ),
+                    },
+                ],
                 "services": {
                     "explore_zone": "weeping_chasm",
                     "gloom_level": 25,
@@ -89,6 +108,27 @@ REMNANTS = {
                     "A folded note is pinned to the post with a Guild insignia pin.\n\n"
                     "*\"Gone at dark. You should be too. — O.\"*"
                 ),
+                "on_enter": [
+                    {
+                        "condition": "first_visit",
+                        "flag": "visited_wardens_post",
+                        "text": (
+                            "Orin glances up from his logbook. *\"Road's passable. "
+                            "Mostly. Don't linger at the edge — the creatures here "
+                            "are drawn to the source and they don't watch where they're going.\"*"
+                        ),
+                    },
+                    {
+                        "condition": "flag:quest_a_guildsmans_first_steps_completed",
+                        "once": True,
+                        "flag": "orin_recruit_acknowledged",
+                        "text": (
+                            "Orin looks up, recognizes the Guild insignia. "
+                            "*\"Recruit. Good — you made it this far.\"* "
+                            "A pause. *\"That's not nothing.\"*"
+                        ),
+                    },
+                ],
                 "services": {},
                 "npcs": {
                     "warden_orin": {
@@ -96,6 +136,18 @@ REMNANTS = {
                         "role": "Guild Warden",
                         "emoji": "🛡️",
                         "availability": "day",
+                        "pet": {
+                            "species": "Barkback",
+                            "nickname": None,
+                            "nickname_visible_flag": None,
+                            "description": (
+                                "A Barkback sits at Orin's side, quiet and watchful. "
+                                "It evolved from a Pineling issued early in his posting. "
+                                "Tough, reliable. Doesn't flinch at the cold air anymore. "
+                                "Neither does Orin."
+                            ),
+                            "player_species_reactions": {},
+                        },
                         "dialogue": {
                             "default": (
                                 "This is as close as most people get. The Chasm draws "
@@ -109,6 +161,16 @@ REMNANTS = {
                             "returning_recruit": (
                                 "Ah — a Guild recruit. Good. The road east gets worse before "
                                 "it gets better. Keep your pet fed and your energy up."
+                            ),
+                            "lore_east_wall": (
+                                "*\"The east section of the wall is webbed over some mornings. "
+                                "Something large made that overnight.\"* "
+                                "He doesn't elaborate. *\"I don't go near it.\"*"
+                            ),
+                            "lore_breathing": (
+                                "*\"Some mornings the mist is different. Heavier. "
+                                "Like something exhaled the whole of it at once.\"* "
+                                "He says it the way you'd report weather."
                             ),
                         },
                     },
@@ -131,6 +193,18 @@ REMNANTS = {
                     "The lamp is still burning. The notebooks are still open. "
                     "Kael doesn't sleep much when he's onto something."
                 ),
+                "on_enter": [
+                    {
+                        "condition": "first_visit",
+                        "flag": "visited_scholars_camp",
+                        "text": (
+                            "Kael looks up immediately, already talking. "
+                            "*\"You're here — good. I've been waiting for someone "
+                            "Vexia would actually trust with this. "
+                            "The origin point is right here and nobody studies it properly.\"*"
+                        ),
+                    },
+                ],
                 "services": {},
                 "npcs": {
                     "lore_keeper_kael": {
@@ -138,6 +212,24 @@ REMNANTS = {
                         "role": "Guild Scholar",
                         "emoji": "🔬",
                         "availability": "all",
+                        "pet": {
+                            "species": "Duskspinner",
+                            "nickname": "threnody",
+                            "nickname_visible_flag": None,  # Kael tells everyone immediately
+                            "description": (
+                                "A Duskspinner perches on the edge of Kael's equipment case, "
+                                "perfectly still. He named it Threnody — a funeral song — "
+                                "after the Gloom's origin in collective sorrow. "
+                                "He will explain the etymology if asked. You didn't ask."
+                            ),
+                            "player_species_reactions": {
+                                "Grimweave": (
+                                    "*\"Oh, a Grimweave. Threnody's base form — "
+                                    "interesting choice for a traveler. "
+                                    "Give it time and the right conditions.\"*"
+                                ),
+                            },
+                        },
                         "dialogue": {
                             "default": (
                                 "You found me. Good — I wasn't sure Vexia would send anyone "
@@ -150,6 +242,26 @@ REMNANTS = {
                                 "unlike anything recorded further out. When you reach the "
                                 "Oasis, find the Obsidian Monoliths. I'll be there. "
                                 "There's something I need to show you."
+                            ),
+                            "lore_gloom_origin": (
+                                "The Gloom didn't spread from a single point by accident. "
+                                "Every record points here — the Chasm — as the breach site. "
+                                "My theory: collective grief. A catastrophic loss, enough "
+                                "souls in enough pain at once to tear something open. "
+                                "The Guild doesn't like that theory. Too difficult to quantify."
+                            ),
+                            "lore_hollowed_vs_corrupted": (
+                                "Corrupted pets can still be reached — the Gloom has touched "
+                                "them but hasn't consumed them. There's still something there "
+                                "to work with. Hollowed is different. When a creature Hollows, "
+                                "there's nothing left that remembers being a creature. "
+                                "That distinction matters. Remember it."
+                            ),
+                            "lore_east_wall": (
+                                "He shows you a single research note. "
+                                "*'Specimen of unusual scale observed on east face. "
+                                "Preliminary classification impossible.'* "
+                                "One entry. The next page is blank."
                             ),
                         },
                     },
@@ -172,6 +284,28 @@ REMNANTS = {
                     "She's always awake at night — she learned not to sleep deeply here "
                     "a long time ago."
                 ),
+                "on_enter": [
+                    {
+                        "condition": "first_visit",
+                        "flag": "visited_lookout_hollow",
+                        "text": (
+                            "Gretta looks up from the fire. Takes you in once, top to bottom. "
+                            "*\"Guild sends another one.\"* She looks back at the fire. "
+                            "*\"They always look the same.\"*"
+                        ),
+                    },
+                    {
+                        "condition": "has_pet_species:Threshling",
+                        "once": True,
+                        "flag": "gretta_threshling_reaction_seen",
+                        "text": (
+                            "Gretta's eyes go to your pet. Stay there longer than usual. "
+                            "*\"You caught one of those.\"* Not a question. "
+                            "She looks back at the half-solid shape near her fire. "
+                            "Doesn't say anything else."
+                        ),
+                    },
+                ],
                 "services": {
                     "rest": {
                         "type": "rough_camp",
@@ -191,6 +325,18 @@ REMNANTS = {
                         "role": "Chasm Watcher",
                         "emoji": "🗡️",
                         "availability": "all",
+                        "pet": {
+                            "species": "Threshling",
+                            "nickname": None,
+                            "nickname_visible_flag": None,
+                            "description": (
+                                "Something half-solid crouches near Gretta's fire. "
+                                "Parts of it solid, parts mist. One eye clear, one eye dark. "
+                                "She didn't purify it. She made it clear who was in charge. "
+                                "It stays because she makes it stay."
+                            ),
+                            "player_species_reactions": {},
+                        },
                         "dialogue": {
                             "default": (
                                 "Guild sends another one. They always look the same — "
@@ -208,6 +354,19 @@ REMNANTS = {
                                 "I've watched that fail more times than you've been alive. "
                                 "Control is not cruelty. It's honesty. "
                                 "There's another way — if you're willing to hear it."
+                            ),
+                            "lore_deep_chasm": (
+                                "*\"Nothing worth finding out there.\"*"
+                            ),
+                            "lore_deep_chasm_pressed": (
+                                "She looks at you for a long moment. "
+                                "*\"The breathing. You've heard it. "
+                                "Don't go looking for what makes it.\"*"
+                            ),
+                            "returning_high_rank": (
+                                "She looks you over once. Looks back at the fire. "
+                                "*\"Still here.\"* That's all she gives you. "
+                                "From Gretta, it means something."
                             ),
                         },
                     },


### PR DESCRIPTION
## Summary
- **Ancient rarity tier** — added between Rare and Legendary; Veilmother and Threshbound are first Ancients
- **Evolution renames** — Sludge Shell→Grimplate, Ossuary Golem→Blightcrust, Gloom Weaver→Grimweave, Dreadspinner→Duskspinner. Skill trees unchanged. Encounter tables updated.
- **Veilmother** — Ancient stub added to Grimweave line; lives on Chasm east wall, theoretically capturable at Legend rank
- **New species** — Gauntling→Waneling (Ghost/Normal), Rimecrawl→Frostbile (Ice/Poison), Threshling→Threshbound (Dark/Ghost, Ancient); all Gloom-touched, `is_gloom_touched: False` NOT set
- **weeping_chasm encounter table** — day/night with evolution stage low-chance entries; Threshling night-only; Threshbound/Veilmother/Chasmbane not in table
- **NPC pets** — Orin (Barkback, no nickname), Kael (Duskspinner, nicknamed Threnody — public), Gretta (Threshling, no nickname)
- **NPC dialogue** — Orin: `lore_east_wall`, `lore_breathing`; Kael: `lore_gloom_origin`, `lore_hollowed_vs_corrupted`, `lore_east_wall`; Gretta: `lore_deep_chasm`, `lore_deep_chasm_pressed`, `returning_high_rank`
- **on_enter all 4 locations** — Chasm's Edge (first visit + night), Warden's Post (first visit + returning recruit acknowledgement), Scholar's Camp (Kael first visit), Lookout Hollow (first visit + Threshling reaction)
- **14 explore events** — flavor (2 night-only), pet sightings (Veilmother east wall night), hazards, loot bonus, sealed journal choice event (lore_fragment + Gloom tick), 2 apex lore events (Chasmbane Gloom spike, Veilmother scale sighting)
- **New items** — `lore_fragment` (with full lore text), `gloom_mist_sample` (quest item stub)

## Tagged for quest line session
- `echoes_from_below` quest (Vexia → Kael → samples → Oasis hook)
- Rank-gated apex encounter system (Veilmother battle, Chasmbane scare logic)
- Chasm-specific item drops

## Test plan
- [ ] Enter Chasm's Edge — first visit pop fires, night pop fires at night
- [ ] Enter Warden's Post — Orin greeting fires; returning recruit line fires once with flag
- [ ] Enter Scholar's Camp (with active quest) — Kael greeting fires
- [ ] Enter Lookout Hollow with a Threshling — Gretta reacts once
- [ ] Explore Weeping Chasm — events fire; night-only events don't fire during day
- [ ] Sealed journal choice — lore_fragment received, no Gloom tick system error
- [ ] Whisperwood/Mirefields — encounter table shows Grimweave not Gloom Weaver

🤖 Generated with [Claude Code](https://claude.com/claude-code)