### PR TITLE
Oakhaven Outpost foundation — NPC pets, encounter depth, on_enter

### DIFF
--- a/cogs/adventure.py
+++ b/cogs/adventure.py
@@ -206,7 +206,7 @@ class Adventure(commands.Cog):
                     return
 
                 if outcome == "tutorial_pet":
-                    chosen_species_name, level = "Pineling", 1
+                    chosen_species_name, level = "Bristlecone", 1
                 else:
                     # time_of_day already resolved above
                     # Map 4 phases to encounter table keys (day/night)

--- a/cogs/views/towns.py
+++ b/cogs/views/towns.py
@@ -1389,8 +1389,16 @@ class TownView(discord.ui.View):
         inventory = await db_cog.get_player_inventory(self.user_id)
         owned_items = {i['item_id'] for i in inventory}
 
+        # Build player rank for required_rank checks
+        from utils.helpers import get_player_rank_info
+        from utils.constants import CREST_RANKS
+        num_crests = await db_cog.count_player_crests(self.user_id)
+        player_rank = get_player_rank_info(num_crests)['rank']
+        rank_order = [r['rank'] for r in CREST_RANKS]
+        player_rank_index = rank_order.index(player_rank) if player_rank in rank_order else 0
+
         _req_keys = ("required_flag", "required_item", "required_quest_status",
-                     "required_quest_step", "required_time")
+                     "required_quest_step", "required_time", "required_rank")
 
         for node in dialogue_tree:
             # --- required_flag ---
@@ -1427,6 +1435,13 @@ class TownView(discord.ui.View):
             # --- required_time: list of valid time-of-day phases ---
             if "required_time" in node:
                 if time_of_day not in node["required_time"]:
+                    continue
+
+            # --- required_rank: minimum rank (by CREST_RANKS order) ---
+            if "required_rank" in node:
+                req_rank = node["required_rank"]
+                req_rank_index = rank_order.index(req_rank) if req_rank in rank_order else 0
+                if player_rank_index < req_rank_index:
                     continue
 
             # Node passed all checks — return it if it has any required key

--- a/data/dialogues.py
+++ b/data/dialogues.py
@@ -7,6 +7,7 @@
 #   required_quest_status — {"quest_id": "x", "status": "active"|"completed"|"failed"}
 #   required_quest_step  — {"quest_id": "x", "step": N}  (matches when count == N)
 #   required_time        — list of valid phases: ["morning","noon","evening","night"]
+#   required_rank        — minimum player rank by CREST_RANKS order (e.g. "Veteran")
 #
 # text / default can be a string OR a list — a list picks a random line each visit.
 
@@ -130,6 +131,11 @@ DIALOGUES = {
         "name": "Grit Galen", "role": "Scavenger",
         "dialogue_tree": [
 
+            # --- Quest completed, Veteran rank or above ---
+            {"required_flag": "quest_sunk_cost_completed",
+             "required_rank": "Veteran",
+             "text": "You made it this far. Good. Come back when you've seen the Chasm. Tell me if what's down there looks anything like what's in the Pits."},
+
             # --- Quest completed ---
             {"required_flag": "quest_sunk_cost_completed",
              "text": [
@@ -137,6 +143,7 @@ DIALOGUES = {
                  "You know, I prospected these pits for six years before I quit. Some things down there still follow me in my sleep.",
                  "The Gloom takes things. Tools, time, people. You did good getting that satchel back.",
                  "Not many Guildsmen would bother with a scavenger's lost kit. I won't forget it.",
+                 "The far edge moved another foot this week. Don't put that in any report.",
              ]},
 
             # --- Quest failed ---

--- a/data/explore_events.py
+++ b/data/explore_events.py
@@ -117,7 +117,7 @@ EXPLORE_EVENTS = {
                 {
                     "label": "Investigate",
                     "emoji": "🔍",
-                    "text": "You clear the rubble and find a startled Pineling, unhurt. It bolts the moment it is free. Small victories.",
+                    "text": "You clear the rubble and find a startled Bristlecone, unhurt. It bolts the moment it is free. Small victories.",
                     "outcome": {"energy": 1},
                 },
                 {
@@ -144,7 +144,7 @@ EXPLORE_EVENTS = {
         {
             "type": "flavor",
             "weight": 10,
-            "text": "A Pineling watches you from a low branch, perfectly still. The moment you look directly at it, it vanishes into the underbrush without a sound.",
+            "text": "A Bristlecone watches you from a low branch, perfectly still. The moment you look directly at it, it vanishes into the underbrush without a sound.",
         },
         {
             "type": "flavor",
@@ -171,7 +171,7 @@ EXPLORE_EVENTS = {
         {
             "type": "pet_sighting",
             "weight": 7,
-            "text": "Two Pinelings chase each other through the canopy at reckless speed, crashing through branches and raining bark down around you. Neither one acknowledges your presence.",
+            "text": "Two Bristlecones chase each other through the canopy at reckless speed, crashing through branches and raining bark down around you. Neither one acknowledges your presence.",
         },
 
         # --- Loot Bonus ---

--- a/data/pets.py
+++ b/data/pets.py
@@ -897,12 +897,12 @@ def get_pet_data(species: str) -> dict:
 ENCOUNTER_TABLES = {
 
     "outpostWilds": {
-        "day": ["Bristlecone"],
-        "night": ["Bristlecone"]
+        "day": ["Bristlecone", "Bristlecone", "Bristlecone", "Mossling"],   # Mossling ~25% — forest edge glimpse
+        "night": ["Bristlecone", "Bristlecone", "Bristlecone", "Mossling"]  # Mossling ~25% — lost
     },
     "oakhavenOutpost_rottingPits": {
         "day": ["Corroder"],
-        "night": ["Corroder"]  # No need to duplicate the whole pet object
+        "night": ["Corroder", "Corroder", "Corroder", "Grimplate"]  # Grimplate ~25% — surfaces after dark
     },
     "whisperwoodGrove": {
         "day": ["Mossling", "Sunpetal Moth"],

--- a/data/pets.py
+++ b/data/pets.py
@@ -172,8 +172,8 @@ PET_DATABASE = {
     },
 
     # --- Oakhaven Outpost Pets ---
-    "Pineling": {
-        "species": "Pineling",
+    "Bristlecone": {
+        "species": "Bristlecone",
         "pet_type": "Normal",
         "rarity": "Common",
         "personality": "Defensive",
@@ -194,9 +194,9 @@ PET_DATABASE = {
             "13": {"choice": ["splinter_strike", "ironbark"]}
         },
         "evolutions": {
-            "Barkback": {
+            "Burlback": {
                 "evolves_at": 16,
-                "species": "Barkback",
+                "species": "Burlback",
                 "pet_type": ["Normal", "Grass"],
                 "rarity": "Uncommon",
                 "description": "A sturdy, tree-stump-like creature whose bark has hardened into thick natural armor. Gnarled branches sprout from its back, and its slow, deliberate movements carry the weight of something ancient and unyielding.",
@@ -897,8 +897,8 @@ def get_pet_data(species: str) -> dict:
 ENCOUNTER_TABLES = {
 
     "outpostWilds": {
-        "day": ["Pineling"],
-        "night": ["Pineling"]
+        "day": ["Bristlecone"],
+        "night": ["Bristlecone"]
     },
     "oakhavenOutpost_rottingPits": {
         "day": ["Corroder"],

--- a/data/remnants.py
+++ b/data/remnants.py
@@ -137,12 +137,12 @@ REMNANTS = {
                         "emoji": "🛡️",
                         "availability": "day",
                         "pet": {
-                            "species": "Barkback",
+                            "species": "Burlback",
                             "nickname": None,
                             "nickname_visible_flag": None,
                             "description": (
-                                "A Barkback sits at Orin's side, quiet and watchful. "
-                                "It evolved from a Pineling issued early in his posting. "
+                                "A Burlback sits at Orin's side, quiet and watchful. "
+                                "It evolved from a Bristlecone issued early in his posting. "
                                 "Tough, reliable. Doesn't flinch at the cold air anymore. "
                                 "Neither does Orin."
                             ),

--- a/data/remnants.py
+++ b/data/remnants.py
@@ -137,14 +137,13 @@ REMNANTS = {
                         "emoji": "🛡️",
                         "availability": "day",
                         "pet": {
-                            "species": "Burlback",
+                            "species": "Frostbile",
                             "nickname": None,
                             "nickname_visible_flag": None,
                             "description": (
-                                "A Burlback sits at Orin's side, quiet and watchful. "
-                                "It evolved from a Bristlecone issued early in his posting. "
-                                "Tough, reliable. Doesn't flinch at the cold air anymore. "
-                                "Neither does Orin."
+                                "A Frostbile moves along the chasm wall a few feet behind Orin, "
+                                "unhurried. It followed him for weeks before he stopped chasing "
+                                "it off. He does not consider that a bonding experience."
                             ),
                             "player_species_reactions": {},
                         },

--- a/data/skills.py
+++ b/data/skills.py
@@ -1679,7 +1679,7 @@ PET_SKILLS = {
         }
     },
 
-    # --- Pineling / Barkback Skills ---
+    # --- Bristlecone / Burlback Skills ---
     "needle_shot": {
         "name": "Needle Shot",
         "power": 40,

--- a/data/towns.py
+++ b/data/towns.py
@@ -41,15 +41,36 @@ TOWNS = {
                 "availability": "day",
                 "description_day": "The main administrative building of the outpost. A large oak desk sits at the far end, behind which you can see Recruitment Officer Elara organizing various Guild contracts and notice board postings.",
                 "description_night": "The hut is dark and quiet, the desk neatly organized for the next day's work. Elara is not present.",
+                "on_enter": [
+                    {
+                        "condition": "first_visit",
+                        "flag": "visited_recruitment_hut",
+                        "once": True,
+                        "text": "In the corner near the door, something low and moss-covered doesn't move when you walk in. It watches you with small amber eyes, then looks away. Elara doesn't mention it."
+                    },
+                    {
+                        "condition": "has_pet_species:Thornmoss",
+                        "flag": "spur_thornmoss_reaction",
+                        "once": True,
+                        "text": "The Thornmoss in the corner raises its head when it sees yours. A long pause. Then it settles back down. Elara glances over but says nothing."
+                    },
+                ],
                 "npcs": {
                     "elara": {
                         "name": "Recruitment Officer Elara",
                         "role": "Guild Officer",
                         "availability": "day",
+                        "pet": {
+                            "species": "Thornmoss",
+                            "nickname": "Spur",
+                            "nickname_visible_flag": None,
+                            "lore": "A Mossling wandered in from the Wilds road years ago and decided the recruitment hut doorstep was home. Elara named it when she was still a recruit herself. Thought she'd be embarrassed by the name later. She wasn't."
+                        },
                         # --- ENHANCED DIALOGUE ---
                         "dialogue": {
                             "default": "Welcome, Adventurer. The Guild welcomes you. I am here to make sure you're ready for the path ahead.",
-                            "quest_the_first_step_step_1": "I see Grit Galen is back from the pits. That old scavenger has seen more of this world than most. You should speak with him."
+                            "quest_the_first_step_step_1": "I see Grit Galen is back from the pits. That old scavenger has seen more of this world than most. You should speak with him.",
+                            "ask_about_pet": "I named him when I was a recruit. Figured I'd regret it. I didn't."
                         }
                     }
                 }
@@ -63,11 +84,29 @@ TOWNS = {
                 "availability": "all",
                 "description": "A large, reinforced chest stocked with basic supplies...",
                 "items_for_sale": ["tether_orb", "moss_balm", "sun_kissed_berries", "trail_morsels"],
+                "on_enter": [
+                    {
+                        "condition": "first_visit",
+                        "flag": "visited_supply_chest",
+                        "once": True,
+                        "text": "Behind the counter, something large and brown is wedged between two crates. It doesn't acknowledge you. Neither does Bea, really. Business as usual, apparently."
+                    },
+                ],
                 "npcs": {
                     "bea": {
                         "name": "Bea",
                         "role": "Supply Merchant",
-                        "availability": "day"
+                        "availability": "day",
+                        "pet": {
+                            "species": "Burlback",
+                            "nickname": "Knot",
+                            "nickname_visible_flag": None,
+                            "lore": "Bea brought a Bristlecone seedling-creature when the outpost was being built and it stayed. It evolved somewhere along the years. She barely noticed. It just got bigger and slower and harder to step around."
+                        },
+                        "dialogue": {
+                            "default": "What do you need? I've got supplies for the road.",
+                            "ask_about_pet": "Oh, it's been here longer than most of the furniture."
+                        }
                     }
                 },
                 "services": {
@@ -109,6 +148,26 @@ TOWNS = {
                 "availability": "all",
                 "description_day": "A series of bubbling tar pits exude a foul, corrupting smell. The air is thick with a palpable sense of Gloom, making the area feel unsettling even in broad daylight. You sense that creatures here are more aggressive.",
                 "description_night": "Under the moonlight, the pits seem to glow with a sickly luminescence. The Gloom is stronger now, and the strange sounds bubbling up from the sludge suggest that the creatures within are even more dangerous.",
+                "on_enter": [
+                    {
+                        "condition": "first_visit",
+                        "flag": "visited_rotting_pits",
+                        "once": True,
+                        "text": "A stick with a strip of red cloth marks the pit's edge. It looks recent — the ground around it is freshly turned. Someone moved it not long ago."
+                    },
+                    {
+                        "condition": "time:night",
+                        "flag": "rotting_pits_night_first",
+                        "once": True,
+                        "text": "Galen isn't here. Neither is Slag. The pits don't care — they glow the same either way. The marker is still there, a little further back than you remember."
+                    },
+                    {
+                        "condition": "flag:visited_chasms_edge",
+                        "flag": "pits_chasm_connection_seen",
+                        "once": True,
+                        "text": "You've seen the Chasm now. Standing at the pit's edge, the smell is the same. The Gloom-haze sits at the same height. You don't know if that means anything. Galen probably does."
+                    },
+                ],
                 "services": {"explore_zone": "oakhavenOutpost_rottingPits",
                              "gloom_level": 20,
                              },
@@ -117,12 +176,21 @@ TOWNS = {
                         "name": "Grit Galen",
                         "role": "Scavenger",
                         "availability": "day",
+                        "pet": {
+                            "species": "Grimplate",
+                            "nickname": "Slag",
+                            "nickname_visible_flag": None,
+                            "lore": "Galen pulled a Corroder out of the Pits seven years ago — it had a claw caught in collapsed tar-stone. He freed it. It followed him home. He called it Slag, a leftover word from the smelting trade. By the time he realized he only used the name for this one, it was too late to change it. It evolved at some point. Galen doesn't remember when."
+                        },
                         # --- ENHANCED DIALOGUE ---
                         "dialogue": {
                             "default": "Don't get too close to the pits, adventurer. The Guild taught you nothing of what lives in there. Only what you can fight.",
                             "quest_offer": "A satchel of my tools lies at the bottom of the pits. It's sinking fast. I can't get it myself. Find it for me, and I'll give you something for your troubles.",
                             "quest_active": "Still looking for my satchel? Be careful down there. The Gloom makes things... twitchy.",
-                            "quest_complete": "You found it! By the Spirits, I thought it was lost for good. Here, take this. It's a compass of sorts. Doesn't point north, but it has a knack for finding things that don't want to be found. Good luck, adventurer."
+                            "quest_complete": "You found it! By the Spirits, I thought it was lost for good. Here, take this. It's a compass of sorts. Doesn't point north, but it has a knack for finding things that don't want to be found. Good luck, adventurer.",
+                            "ask_about_pet": "It came out of the pits. The pits are mine. So it's mine.",
+                            "pit_growth": "The far edge moved another foot this week. Don't put that in any report.",
+                            "returning_high_rank": "You made it this far. Good. Come back when you've seen the Chasm. Tell me if what's down there looks anything like what's in the Pits."
                         }
                     }
                 }

--- a/data/towns.py
+++ b/data/towns.py
@@ -188,9 +188,10 @@ TOWNS = {
                             "quest_offer": "A satchel of my tools lies at the bottom of the pits. It's sinking fast. I can't get it myself. Find it for me, and I'll give you something for your troubles.",
                             "quest_active": "Still looking for my satchel? Be careful down there. The Gloom makes things... twitchy.",
                             "quest_complete": "You found it! By the Spirits, I thought it was lost for good. Here, take this. It's a compass of sorts. Doesn't point north, but it has a knack for finding things that don't want to be found. Good luck, adventurer.",
-                            "ask_about_pet": "It came out of the pits. The pits are mine. So it's mine.",
-                            "pit_growth": "The far edge moved another foot this week. Don't put that in any report.",
-                            "returning_high_rank": "You made it this far. Good. Come back when you've seen the Chasm. Tell me if what's down there looks anything like what's in the Pits."
+                            "ask_about_pet": "It came out of the pits. The pits are mine. So it's mine."
+                            # pit_growth & returning_high_rank now live in data/dialogues.py
+                            # (DIALOGUES['grit_galen']['dialogue_tree']) — that's the dialogue
+                            # source actually used by TownView's talk button.
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- **NPC pets** — Elara (Thornmoss/Spur), Galen (Grimplate/Slag), Bea (Burlback/Knot); each with lore, nickname, and `ask_about_pet` dialogue
- **Galen dialogue variants** — `pit_growth` (post sunk_cost) and `returning_high_rank` (Veteran+) added as data stubs; require dialogue system upgrade to fire conditionally
- **Encounter table depth** — Mossling added to outpostWilds day+night (~25%); Grimplate added to rottingPits night (~25%)
- **on_enter (3 locations)** — recruitment_hut (Spur corner moment + Thornmoss species reaction), supply_chest (Knot first-visit), rotting_pits (marker lore seed, Galen-absent night, Pits/Chasm connection payoff via `visited_chasms_edge` flag)
- **Fix: Warden Orin's pet** — corrected to Frostbile; was set to Barkback in PR #27, became Burlback after rename pass; oakhaven_outpost.md is the authoritative source

## Pending (next sessions)
- Dialogue system upgrade: extend TownView talk callback to resolve `required_flag` / `required_rank` conditions (needed for Galen's conditional lines)
- Quest lines: report_to_elara, sunk_cost follow-up

## Test plan
- [ ] Enter recruitment_hut first time — Spur corner auto-dialogue fires
- [ ] Enter recruitment_hut with a Thornmoss equipped — species reaction fires once
- [ ] Enter supply_chest first time — Knot behind-counter auto-dialogue fires
- [ ] Enter rotting_pits first time (day) — marker lore fires
- [ ] Enter rotting_pits at night — Galen-absent line fires once
- [ ] Enter rotting_pits after visiting Chasm's Edge — connection payoff fires once
- [ ] Explore outpostWilds — Mossling occasionally appears
- [ ] Explore rottingPits at night — Grimplate occasionally appears
- [ ] Talk to Orin at Warden's Post — Frostbile shows in pet display

🤖 Generated with [Claude Code](https://claude.com/claude-code)