### PR TITLE
Classification Tier and Encounter Rarity migration

### DIFF
--- a/cogs/adventure.py
+++ b/cogs/adventure.py
@@ -10,6 +10,7 @@ from discord.ext import commands
 # --- REFACTORED IMPORTS ---
 from data.towns import TOWNS
 from data.pets import PET_DATABASE, ENCOUNTER_TABLES
+from data.classifications import ENCOUNTER_RARITY_WEIGHTS
 from data.items import ITEMS
 from data.abilities import SHARED_PASSIVES_BY_TYPE
 from data.explore_events import get_zone_events, get_zone_loot
@@ -18,6 +19,21 @@ from core.battle_engine import BattleState  # <-- Key Change: Importing from cor
 from .resources import ACTION_COSTS
 from .views.towns import TownView, WildsView, RemnantView
 from .views.combat import CombatView
+
+
+def choose_wild_species(possible_pets):
+    """Pick a species name from an ENCOUNTER_TABLES entry list.
+
+    Supports both the new per-location format
+    (``{"species": ..., "encounter_rarity": ...}``, weighted via
+    ENCOUNTER_RARITY_WEIGHTS) and the legacy flat list of repeated species
+    names (uniform random.choice), so zones can be migrated incrementally.
+    """
+    if isinstance(possible_pets[0], dict):
+        species_names = [entry["species"] for entry in possible_pets]
+        weights = [ENCOUNTER_RARITY_WEIGHTS.get(entry.get("encounter_rarity"), 1) or 1 for entry in possible_pets]
+        return random.choices(species_names, weights=weights, k=1)[0]
+    return random.choice(possible_pets)
 
 
 class Adventure(commands.Cog):
@@ -212,12 +228,12 @@ class Adventure(commands.Cog):
                     # Map 4 phases to encounter table keys (day/night)
                     # Encounter tables can add 'morning'/'noon'/etc keys later for unique spawns
                     encounter_key = 'night' if is_night_time else 'day'
-                    possible_pet_names = (ENCOUNTER_TABLES.get(location_id, {}).get(time_of_day)
-                                          or ENCOUNTER_TABLES.get(location_id, {}).get(encounter_key, []))
-                    if not possible_pet_names:
+                    possible_pets = (ENCOUNTER_TABLES.get(location_id, {}).get(time_of_day)
+                                     or ENCOUNTER_TABLES.get(location_id, {}).get(encounter_key, []))
+                    if not possible_pets:
                         # (Graceful handling for no pets found)
                         return
-                    chosen_species_name = random.choice(possible_pet_names)
+                    chosen_species_name = choose_wild_species(possible_pets)
                     level = random.randint(3, 5)
 
                 wild_pet_base = PET_DATABASE.get(chosen_species_name)
@@ -227,8 +243,18 @@ class Adventure(commands.Cog):
                     return
 
                 # Pet generation logic (stats, passive, skills)
+                # Ordinary/Prime tier species draw from the shared type-based
+                # passive pool; Apex and above keep their unique passive.
+                # Falls back to the legacy rarity check for species not yet
+                # migrated to classification_tier.
+                classification_tier = wild_pet_base.get('classification_tier')
+                if classification_tier is not None:
+                    use_shared_passive = classification_tier in ("Ordinary", "Prime")
+                else:
+                    use_shared_passive = wild_pet_base['rarity'] in ["Common", "Uncommon"]
+
                 assigned_passive = None
-                if wild_pet_base['rarity'] in ["Common", "Uncommon"]:
+                if use_shared_passive:
                     pet_type = wild_pet_base['pet_type']
                     if isinstance(pet_type, list): pet_type = random.choice(pet_type)
                     possible_passives = SHARED_PASSIVES_BY_TYPE.get(pet_type, [])

--- a/data/classifications.py
+++ b/data/classifications.py
@@ -83,16 +83,41 @@ ACTIVE_CLASSIFICATION_TIERS = ["Ordinary", "Prime", "Apex", "Elder", "Ancient"]
 # =================================================================================
 #  ENCOUNTER RARITY
 # =================================================================================
-# How often a creature is actually seen/caught — independent of Classification
-# Tier. A creature's tier rarely changes; its encounter rarity can shift by
-# context (e.g. a Withering-Marked Mossling is still Ordinary tier, but a Rare sighting).
+# How surprising it is to see *this* (species, possibly Gloom-marked) at *this*
+# location — independent of Classification Tier. A creature's tier rarely
+# changes; its encounter rarity is set per (species[+gloom state], location)
+# pair. E.g. a Mossling is Normal in its home grove; a Touched Mossling in that
+# same clean grove would be Odd — the Gloom variant is the anomaly, not the
+# species. In a Gloom-affected zone those readings could flip.
 
 ENCOUNTER_RARITIES = [
-    "Common",
-    "Uncommon",
+    "Normal",
+    "Odd",
     "Rare",
-    # Further tiers TBD as needed.
+    "Peculiar",
+    "Strange",
+    "Uncanny",
+    "Unknown",
 ]
+
+# Selection weights for random.choices()-style weighted picks within an
+# encounter table. Each step is roughly half the previous one, so the table
+# can be tuned just by adjusting which rarity an entry is assigned.
+#
+# "Unknown" is intentionally NOT meant for normal weighted rolls — it reads as
+# "this shouldn't be happening at all" and should be reserved for
+# story/quest-triggered encounters rather than the general wild-encounter pool.
+# It's listed here for completeness/lore use, but encounter tables should
+# avoid using it until there's a dedicated trigger path for it.
+ENCOUNTER_RARITY_WEIGHTS = {
+    "Normal": 32,
+    "Odd": 16,
+    "Rare": 8,
+    "Peculiar": 4,
+    "Strange": 2,
+    "Uncanny": 1,
+    "Unknown": 0,  # excluded from normal weighted rolls — see note above
+}
 
 
 # =================================================================================

--- a/data/pets.py
+++ b/data/pets.py
@@ -11,7 +11,7 @@
 PET_DATABASE = {
     # --- Starter Pets ---
     "Pyrelisk": {
-        "species": "Pyrelisk", "pet_type": "Fire", "rarity": "Starter", "personality": "Aggressive",
+        "species": "Pyrelisk", "pet_type": "Fire", "rarity": "Starter", "classification_tier": "Ordinary", "personality": "Aggressive",
         "description": "A small, lizard-like creature with ember-red scales and a tail that flickers with a perpetual flame. Its eyes glow like hot coals, and it leaves tiny scorch marks wherever it steps.",
         "base_capture_rate": 35,
         "passive_ability": {
@@ -30,7 +30,7 @@ PET_DATABASE = {
         "evolutions": {
             "Blazewyrm": {
                 "evolves_at": 16,
-                "species": "Blazewyrm", "pet_type": ["Fire", "Dragon"], "rarity": "Starter",
+                "species": "Blazewyrm", "pet_type": ["Fire", "Dragon"], "rarity": "Starter", "classification_tier": "Prime",
                 "description": "A more imposing reptilian form, the Blazewyrm is covered in thick, heat-resistant scales and a ridge of sharp, volcanic rock that runs down its back. Its eyes burn with a low, menacing glow.",
                 "base_stat_ranges": {"hp": [60, 65], "attack": [70, 75], "defense": [45, 50], "special_attack": [65, 70],
                                      "special_defense": [45, 50], "speed": [50, 55]},
@@ -45,7 +45,7 @@ PET_DATABASE = {
                 "evolutions": {
                     "Ignisyrn": {
                         "evolves_at": 30,
-                        "species": "Ignisyrn", "pet_type": ["Fire", "Dragon"], "rarity": "Starter",
+                        "species": "Ignisyrn", "pet_type": ["Fire", "Dragon"], "rarity": "Starter", "classification_tier": "Apex",
                         "description": "A fearsome draconic creature with scales that glow like magma and massive wings that beat with a volcanic force. It is the undisputed predator of fiery lands.",
                         "base_stat_ranges": {"hp": [80, 85], "attack": [110, 115], "defense": [60, 65], "special_attack": [100, 105],
                                              "special_defense": [60, 65], "speed": [70, 75]},
@@ -65,7 +65,7 @@ PET_DATABASE = {
     },
 
     "Dewdrop": {
-        "species": "Dewdrop", "pet_type": "Water", "rarity": "Starter", "personality": "Tactical",
+        "species": "Dewdrop", "pet_type": "Water", "rarity": "Starter", "classification_tier": "Ordinary", "personality": "Tactical",
         "description": "A small, teardrop-shaped creature with translucent, water-blue skin that shimmers in the light. Tiny ripples flow across its body when it moves, and a soft gurgling sound follows it everywhere.",
         "base_capture_rate": 35,
         "passive_ability": {
@@ -84,7 +84,7 @@ PET_DATABASE = {
         "evolutions": {
             "Aquarius": {
                 "evolves_at": 16,
-                "species": "Aquarius", "pet_type": ["Water", "Fairy"], "rarity": "Starter",
+                "species": "Aquarius", "pet_type": ["Water", "Fairy"], "rarity": "Starter", "classification_tier": "Prime",
                 "description": "A bipedal, aquatic being with fins that resemble delicate feathers and a body that flows like a river. It moves with a hypnotic, liquid grace.",
                 "base_stat_ranges": {"hp": [60, 65], "attack": [45, 50], "defense": [50, 55], "special_attack": [70, 75],
                                      "special_defense": [65, 70], "speed": [55, 60]},
@@ -99,7 +99,7 @@ PET_DATABASE = {
                 "evolutions": {
                     "Aethelgale": {
                         "evolves_at": 30,
-                        "species": "Aethelgale", "pet_type": ["Water", "Fairy"], "rarity": "Starter",
+                        "species": "Aethelgale", "pet_type": ["Water", "Fairy"], "rarity": "Starter", "classification_tier": "Apex",
                         "description": "A guardian forged from pure, translucent water, its form constantly shifting like a flowing river. It possesses a serene, ancient wisdom in its eyes.",
                         "base_stat_ranges": {"hp": [80, 85], "attack": [60, 65], "defense": [70, 75], "special_attack": [110, 115],
                                              "special_defense": [100, 105], "speed": [75, 80]},
@@ -118,7 +118,7 @@ PET_DATABASE = {
         }
     },
     "Terran": {
-        "species": "Terran", "pet_type": "Ground", "rarity": "Starter", "personality": "Defensive",
+        "species": "Terran", "pet_type": "Ground", "rarity": "Starter", "classification_tier": "Ordinary", "personality": "Defensive",
         "description": "A squat, boulder-shaped creature covered in rough, earthy hide the color of dried clay. Despite its slow movements, it carries an unshakeable solidity, as if it were a small fragment of the earth given life.",
         "base_capture_rate": 35,
         "passive_ability": {
@@ -138,7 +138,7 @@ PET_DATABASE = {
         "evolutions": {
             "Stonehide": {
                 "evolves_at": 16,
-                "species": "Stonehide", "pet_type": ["Ground", "Rock"], "rarity": "Starter",
+                "species": "Stonehide", "pet_type": ["Ground", "Rock"], "rarity": "Starter", "classification_tier": "Prime",
                 "description": "A quadrupedal golem whose body is comprised of dense, layered rock. It has a single, large gem in its chest that glows with the light of the earth.",
                 "base_stat_ranges": {"hp": [65, 70], "attack": [55, 60], "defense": [75, 80], "special_attack": [40, 45],
                                      "special_defense": [50, 55], "speed": [35, 40]},
@@ -152,7 +152,7 @@ PET_DATABASE = {
                 "evolutions": {
                     "Bouldyrn": {
                         "evolves_at": 30,
-                        "species": "Bouldyrn", "pet_type": ["Ground", "Rock"], "rarity": "Starter",
+                        "species": "Bouldyrn", "pet_type": ["Ground", "Rock"], "rarity": "Starter", "classification_tier": "Apex",
                         "description": "A colossal golem with a fortress-like body of polished obsidian and glowing green crystals embedded within its chest. It moves slowly but with immense, unyielding power.",
                         "base_stat_ranges": {"hp": [90, 95], "attack": [75, 80], "defense": [120, 125], "special_attack": [55, 60],
                                              "special_defense": [70, 75], "speed": [45, 50]},
@@ -176,6 +176,7 @@ PET_DATABASE = {
         "species": "Bristlecone",
         "pet_type": "Normal",
         "rarity": "Common",
+        "classification_tier": "Ordinary",
         "personality": "Defensive",
         "description": "A small, pine cone-shaped creature with a tough, bark-like exterior and stubby limbs. Its body is studded with short, sharp needles that bristle outward whenever it senses danger.",
         "base_capture_rate": 45,
@@ -199,6 +200,7 @@ PET_DATABASE = {
                 "species": "Burlback",
                 "pet_type": ["Normal", "Grass"],
                 "rarity": "Uncommon",
+                "classification_tier": "Prime",
                 "description": "A sturdy, tree-stump-like creature whose bark has hardened into thick natural armor. Gnarled branches sprout from its back, and its slow, deliberate movements carry the weight of something ancient and unyielding.",
                 "passive_ability": {
                     "name": "Thorny Hide",
@@ -218,7 +220,7 @@ PET_DATABASE = {
         }
     },
     "Corroder": {
-        "species": "Corroder", "pet_type": ["Rock", "Poison"], "rarity": "Common", "personality": "Defensive",
+        "species": "Corroder", "pet_type": ["Rock", "Poison"], "rarity": "Common", "classification_tier": "Ordinary", "personality": "Defensive",
         "description": "A hunched, crab-like creature whose shell is a patchwork of calcified rock and oozing dark sludge. Its claws drip with a corrosive substance that slowly eats through anything they touch.",
         "is_gloom_touched": True,
         "gloom": {"state": "Touched", "type": "Rotting", "mark": "oozing dark sludge and a corrosive drip from the claws"},
@@ -239,7 +241,7 @@ PET_DATABASE = {
         "evolutions": {
             "Grimplate": {
                 "evolves_at": 15,
-                "species": "Grimplate", "pet_type": ["Rock", "Poison"], "rarity": "Uncommon",
+                "species": "Grimplate", "pet_type": ["Rock", "Poison"], "rarity": "Uncommon", "classification_tier": "Prime",
                 "description": "A larger, more heavily armored successor to the Corroder. Its shell has fused into dense, layered rock, and the toxic sludge it secretes has thickened into a viscous, slow-dripping poison.",
                 "base_stat_ranges": {"hp": [60, 65], "attack": [45, 50], "defense": [70, 75],
                                      "special_attack": [35, 40],
@@ -255,7 +257,7 @@ PET_DATABASE = {
                 "evolutions": {
                     "Blightcrust": {
                         "evolves_at": 30,
-                        "species": "Blightcrust", "pet_type": ["Rock", "Poison"], "rarity": "Rare",
+                        "species": "Blightcrust", "pet_type": ["Rock", "Poison"], "rarity": "Rare", "classification_tier": "Apex",
                         "is_gloom_touched": True,
                         "gloom": {"state": "Shorn", "type": "Rotting", "mark": "fused bones and hardened sludge radiating an aura of decay"},
                         "description": "A towering construct of fused bones and hardened sludge, shaped by years of Gloom exposure into something ancient and terrifying. It moves slowly but radiates an aura of decay that withers anything that lingers too close.",
@@ -716,6 +718,7 @@ PET_DATABASE = {
         "species": "Cinderkit",
         "pet_type": "Fire",
         "rarity": "Common",
+        "classification_tier": "Ordinary",
         "personality": "Timid",
         "description": (
             "A small fox-kit-like creature with ash-gray fur and faint ember-orange "
@@ -743,6 +746,7 @@ PET_DATABASE = {
                 "species": "Ashveil",
                 "pet_type": "Fire",
                 "rarity": "Uncommon",
+                "classification_tier": "Prime",
                 "description": (
                     "Bigger and leaner than Cinderkit. The ember streaks have become "
                     "trailing wisps of smoke and ash that drift behind it as it moves, "
@@ -770,6 +774,7 @@ PET_DATABASE = {
         "species": "Tindertail",
         "pet_type": "Fire",
         "rarity": "Uncommon",
+        "classification_tier": "Prime",
         "personality": "Tactical",
         "description": (
             "A small, quick, alert creature — more scout than fighter. Slim, "
@@ -798,6 +803,7 @@ PET_DATABASE = {
         "species": "Smolderoot",
         "pet_type": ["Grass", "Fire"],
         "rarity": "Uncommon",
+        "classification_tier": "Prime",
         "personality": "Defensive",
         "description": (
             "Looks like a charred sapling that somehow kept growing — blackened "
@@ -825,6 +831,7 @@ PET_DATABASE = {
                 "species": "Pyrethorn",
                 "pet_type": ["Grass", "Fire"],
                 "rarity": "Rare",
+                "classification_tier": "Apex",
                 "description": (
                     "Smolderoot's larger form — gnarled, root-legged, hunched, walking "
                     "on four thorned root-limbs with low flame constantly licking along "
@@ -852,6 +859,7 @@ PET_DATABASE = {
         "species": "Cindermaw",
         "pet_type": ["Grass", "Fire"],
         "rarity": "Ancient",
+        "classification_tier": "Elder",
         "personality": "Defensive",
         "description": (
             "A massive, mostly inert charred root-mass, half-buried in deep ash at "
@@ -881,6 +889,7 @@ PET_DATABASE = {
         "species": "Pyrehart",
         "pet_type": "Fire",
         "rarity": "Ancient",
+        "classification_tier": "Elder",
         "personality": "Aggressive",
         "description": (
             "A large, lion-or-wolf-shaped guardian, its 'fur' made of slow-moving "
@@ -912,7 +921,7 @@ PET_DATABASE = {
     # -------------------------------------------------------------------------
 
     "Stillroot": {
-        "species": "Stillroot", "pet_type": ["Rock", "Grass"], "rarity": "Common",
+        "species": "Stillroot", "pet_type": ["Rock", "Grass"], "rarity": "Common", "classification_tier": "Ordinary",
         "personality": "Steadfast",
         "is_gloom_touched": True,
         "gloom": {"state": "Touched", "type": "Calcifying", "mark": "patches of genuine stone-like growth across the body, stalled in place"},
@@ -945,7 +954,7 @@ PET_DATABASE = {
     },
 
     "Veinglow": {
-        "species": "Veinglow", "pet_type": ["Poison", "Grass"], "rarity": "Uncommon",
+        "species": "Veinglow", "pet_type": ["Poison", "Grass"], "rarity": "Uncommon", "classification_tier": "Prime",
         "personality": "Cautious",
         "is_gloom_touched": False,
         "description": (
@@ -983,7 +992,7 @@ PET_DATABASE = {
     # -------------------------------------------------------------------------
 
     "Gauntling": {
-        "species": "Gauntling", "pet_type": ["Ghost", "Normal"], "rarity": "Common",
+        "species": "Gauntling", "pet_type": ["Ghost", "Normal"], "rarity": "Common", "classification_tier": "Ordinary",
         "personality": "Timid",
         "is_gloom_touched": True,
         "gloom": {"state": "Touched", "type": "Fading", "mark": "partially translucent body, slowly losing physical definition"},
@@ -1014,7 +1023,7 @@ PET_DATABASE = {
         "evolutions": {
             "Waneling": {
                 "evolves_at": 15,
-                "species": "Waneling", "pet_type": ["Ghost", "Normal"], "rarity": "Uncommon",
+                "species": "Waneling", "pet_type": ["Ghost", "Normal"], "rarity": "Uncommon", "classification_tier": "Prime",
                 "is_gloom_touched": True,
                 "gloom": {"state": "Shorn", "type": "Fading", "mark": "more ghost than creature, barely visible — sensed more than seen"},
                 "description": (
@@ -1040,7 +1049,7 @@ PET_DATABASE = {
     },
 
     "Rimecrawl": {
-        "species": "Rimecrawl", "pet_type": ["Ice", "Poison"], "rarity": "Uncommon",
+        "species": "Rimecrawl", "pet_type": ["Ice", "Poison"], "rarity": "Uncommon", "classification_tier": "Prime",
         "personality": "Defensive",
         "is_gloom_touched": True,
         "gloom": {"state": "Touched", "type": "Frostbound", "mark": "trails of frost-laced Gloom residue, cold to the touch"},
@@ -1071,7 +1080,7 @@ PET_DATABASE = {
         "evolutions": {
             "Frostbile": {
                 "evolves_at": 16,
-                "species": "Frostbile", "pet_type": ["Ice", "Poison"], "rarity": "Rare",
+                "species": "Frostbile", "pet_type": ["Ice", "Poison"], "rarity": "Rare", "classification_tier": "Apex",
                 "is_gloom_touched": True,
                 "gloom": {"state": "Shorn", "type": "Frostbound", "mark": "crystallized frost trails that turn the terrain itself into a weapon"},
                 "description": (
@@ -1097,7 +1106,7 @@ PET_DATABASE = {
     },
 
     "Threshling": {
-        "species": "Threshling", "pet_type": ["Dark", "Ghost"], "rarity": "Rare",
+        "species": "Threshling", "pet_type": ["Dark", "Ghost"], "rarity": "Rare", "classification_tier": "Apex",
         "personality": "Aggressive",
         "is_gloom_touched": True,
         "gloom": {"state": "Shorn", "type": "Thresholdbound", "mark": "half-solid, half-mist body; one eye clear, one eye dark"},
@@ -1128,7 +1137,7 @@ PET_DATABASE = {
         "evolutions": {
             "Threshbound": {
                 "evolves_at": 20,
-                "species": "Threshbound", "pet_type": ["Dark", "Ghost"], "rarity": "Ancient",
+                "species": "Threshbound", "pet_type": ["Dark", "Ghost"], "rarity": "Ancient", "classification_tier": "Elder",
                 "is_gloom_touched": True,
                 "gloom": {"state": "Hollow", "type": "Thresholdbound", "mark": "no longer at the threshold — it IS the threshold, defying classification"},
                 "description": (
@@ -1165,7 +1174,7 @@ PET_DATABASE = {
     # -------------------------------------------------------------------------
 
     "Murkback": {
-        "species": "Murkback", "pet_type": ["Water", "Ground"], "rarity": "Common",
+        "species": "Murkback", "pet_type": ["Water", "Ground"], "rarity": "Common", "classification_tier": "Ordinary",
         "personality": "Defensive",
         "description": (
             "A squat, wide-bodied amphibian armored with a crust of dried mud and silt. "
@@ -1193,7 +1202,7 @@ PET_DATABASE = {
         "evolutions": {
             "Murkwall": {
                 "evolves_at": 15,
-                "species": "Murkwall", "pet_type": ["Water", "Ground"], "rarity": "Uncommon",
+                "species": "Murkwall", "pet_type": ["Water", "Ground"], "rarity": "Uncommon", "classification_tier": "Prime",
                 "description": (
                     "Larger, slower, and nearly immovable. The hide has thickened into "
                     "layered mud-rock plating. Murkback's territorial instinct has become "
@@ -1219,7 +1228,7 @@ PET_DATABASE = {
     },
 
     "Pallefin": {
-        "species": "Pallefin", "pet_type": "Water", "rarity": "Uncommon",
+        "species": "Pallefin", "pet_type": "Water", "rarity": "Uncommon", "classification_tier": "Prime",
         "personality": "Timid",
         "description": (
             "A small, almost translucent creature that skims the water surface without "
@@ -1248,7 +1257,7 @@ PET_DATABASE = {
         "evolutions": {
             "Shimmerdeep": {
                 "evolves_at": 16,
-                "species": "Shimmerdeep", "pet_type": "Water", "rarity": "Rare",
+                "species": "Shimmerdeep", "pet_type": "Water", "rarity": "Rare", "classification_tier": "Apex",
                 "description": (
                     "No longer skims the surface — descends. The translucency becomes "
                     "a faint bioluminescence, generating soft light in dark water. "
@@ -1274,7 +1283,7 @@ PET_DATABASE = {
     },
 
     "Siltborn": {
-        "species": "Siltborn", "pet_type": ["Poison", "Grass"], "rarity": "Rare",
+        "species": "Siltborn", "pet_type": ["Poison", "Grass"], "rarity": "Rare", "classification_tier": "Apex",
         "personality": "Aggressive",
         "is_gloom_touched": False,
         "description": (
@@ -1304,7 +1313,7 @@ PET_DATABASE = {
         "evolutions": {
             "Mirewarden": {
                 "evolves_at": 18,
-                "species": "Mirewarden", "pet_type": ["Poison", "Grass"], "rarity": "Very Rare",
+                "species": "Mirewarden", "pet_type": ["Poison", "Grass"], "rarity": "Very Rare", "classification_tier": "Elder",
                 "is_gloom_touched": False,
                 "description": (
                     "Larger, denser. Reeds and roots have grown through it, not just "
@@ -1365,19 +1374,31 @@ def get_pet_data(species: str) -> dict:
 
 ENCOUNTER_TABLES = {
 
-    "outpostWilds": {
-        "day": ["Bristlecone", "Bristlecone", "Bristlecone", "Mossling"],   # Mossling ~25% — forest edge glimpse
-        "night": ["Bristlecone", "Bristlecone", "Bristlecone", "Mossling"]  # Mossling ~25% — lost
-    },
-    "oakhavenOutpost_rottingPits": {
-        "day": ["Corroder"],
-        "night": ["Corroder", "Corroder", "Corroder", "Grimplate"]  # Grimplate ~25% — surfaces after dark
-    },
     # Encounter Rarity is relative to THIS location, not an intrinsic property
     # of the species (see data/classifications.py — ENCOUNTER_RARITIES /
     # ENCOUNTER_RARITY_WEIGHTS). Same species can read differently at
-    # different locations; Gloom-touched species are "Odd" in their home
-    # territory as a baseline for that signal to escalate elsewhere later.
+    # different locations; Gloom-touched species are "Normal" in their own
+    # heavily Gloom-affected home turf, but "Odd" (or further) where they're
+    # an out-of-place anomaly — that's the signal for Gloom-spread later.
+    "outpostWilds": {
+        "day": [
+            {"species": "Bristlecone", "encounter_rarity": "Normal"},
+            {"species": "Mossling", "encounter_rarity": "Odd"},  # forest edge glimpse
+        ],
+        "night": [
+            {"species": "Bristlecone", "encounter_rarity": "Normal"},
+            {"species": "Mossling", "encounter_rarity": "Odd"},  # lost
+        ],
+    },
+    "oakhavenOutpost_rottingPits": {
+        "day": [
+            {"species": "Corroder", "encounter_rarity": "Normal"},  # Gloom-touched, this is its home
+        ],
+        "night": [
+            {"species": "Corroder", "encounter_rarity": "Normal"},
+            {"species": "Grimplate", "encounter_rarity": "Odd"},  # surfaces after dark
+        ],
+    },
     "whisperwoodGrove": {
         "day": [
             {"species": "Mossling", "encounter_rarity": "Normal"},
@@ -1408,22 +1429,70 @@ ENCOUNTER_TABLES = {
         # The Ash Circle — Tindertail intentionally absent (Bram & Pip's shared
         # companion, not a wild population). The First Ring is folded into this
         # table as rare/very-rare sightings rather than its own zone for now.
-        "day": ["Mossling", "Mossling", "Cinderkit", "Cinderkit", "Pyrethorn"],  # Pyrethorn ~20% — First Ring, rare daytime sighting
-        "night": ["Mossling", "Mossling", "Cinderkit", "Cinderkit", "Cinderkit", "Grimweave", "Smolderoot", "Smolderoot", "Cindermaw", "Pyrehart"]  # Cindermaw/Pyrehart ~10% each — ancient, very rare
+        "day": [
+            {"species": "Mossling", "encounter_rarity": "Normal"},
+            {"species": "Cinderkit", "encounter_rarity": "Normal"},
+            {"species": "Pyrethorn", "encounter_rarity": "Rare"},  # First Ring, rare daytime sighting
+        ],
+        "night": [
+            {"species": "Cinderkit", "encounter_rarity": "Normal"},
+            {"species": "Mossling", "encounter_rarity": "Odd"},
+            {"species": "Grimweave", "encounter_rarity": "Odd"},  # Gloom-touched
+            {"species": "Smolderoot", "encounter_rarity": "Odd"},
+            {"species": "Cindermaw", "encounter_rarity": "Strange"},  # Elder tier, ancient/very-rare sighting
+            {"species": "Pyrehart", "encounter_rarity": "Strange"},  # Elder tier, ancient/very-rare sighting
+        ],
     },
     "mirefields": {
-        "day": ["Murkback", "Pallefin", "Mossling", "Corroder"],
-        "night": ["Murkback", "Grimweave", "Siltborn", "Corroder"],
+        "day": [
+            {"species": "Murkback", "encounter_rarity": "Normal"},
+            {"species": "Pallefin", "encounter_rarity": "Normal"},
+            {"species": "Mossling", "encounter_rarity": "Normal"},
+            {"species": "Corroder", "encounter_rarity": "Normal"},  # Gloom-touched, at home in the mire
+        ],
+        "night": [
+            {"species": "Murkback", "encounter_rarity": "Normal"},
+            {"species": "Corroder", "encounter_rarity": "Normal"},  # Gloom-touched, at home in the mire
+            {"species": "Grimweave", "encounter_rarity": "Odd"},  # Gloom-touched, away from its Whisperwood home
+            {"species": "Siltborn", "encounter_rarity": "Odd"},  # night-only resident, not Gloom-touched
+        ],
     },
     "weeping_chasm": {
-        "day": ["Gauntling", "Rimecrawl", "Corroder"],
-        "night": ["Gauntling", "Rimecrawl", "Grimweave", "Corroder", "Waneling", "Frostbile", "Grimplate", "Threshling"],
+        # Heavily Gloom-affected zone — the Touched/Shorn residents listed here
+        # are "Normal" sightings in their own home territory.
+        "day": [
+            {"species": "Gauntling", "encounter_rarity": "Normal"},  # Gloom-touched, at home
+            {"species": "Rimecrawl", "encounter_rarity": "Normal"},  # Gloom-touched, at home
+            {"species": "Corroder", "encounter_rarity": "Normal"},  # Gloom-touched, at home
+        ],
+        "night": [
+            {"species": "Gauntling", "encounter_rarity": "Normal"},
+            {"species": "Rimecrawl", "encounter_rarity": "Normal"},
+            {"species": "Corroder", "encounter_rarity": "Normal"},
+            {"species": "Grimweave", "encounter_rarity": "Odd"},  # Gloom-touched, away from its Whisperwood home
+            {"species": "Waneling", "encounter_rarity": "Odd"},  # Shorn evolution, less common than Gauntling
+            {"species": "Frostbile", "encounter_rarity": "Odd"},  # Shorn evolution, less common than Rimecrawl
+            {"species": "Grimplate", "encounter_rarity": "Odd"},  # evolution, less common than Corroder
+            {"species": "Threshling", "encounter_rarity": "Rare"},  # Gretta's threshold-bound capture, very low base capture rate
+        ],
     },
     "weepingRoot": {
         # Underground, no real day/night cycle — both keys use the same table.
         # Mossling/Serpentine/Glamorose here are Withering-Marked (flavor-only
         # for now; see EXPLORE_EVENTS["weepingRoot"] and on_enter text).
-        "day": ["Mossling", "Mossling", "Mossling", "Serpentine", "Glamorose", "Veinglow", "Veinglow", "Stillroot"],  # Stillroot ~12.5% — rare, Calcifying alongside Withering
-        "night": ["Mossling", "Mossling", "Mossling", "Serpentine", "Glamorose", "Veinglow", "Veinglow", "Stillroot"],
+        "day": [
+            {"species": "Mossling", "encounter_rarity": "Normal"},
+            {"species": "Veinglow", "encounter_rarity": "Normal"},  # native to the Root, adapted to the sap-veins
+            {"species": "Serpentine", "encounter_rarity": "Odd"},
+            {"species": "Glamorose", "encounter_rarity": "Odd"},
+            {"species": "Stillroot", "encounter_rarity": "Rare"},  # rare, Calcifying alongside Withering
+        ],
+        "night": [
+            {"species": "Mossling", "encounter_rarity": "Normal"},
+            {"species": "Veinglow", "encounter_rarity": "Normal"},
+            {"species": "Serpentine", "encounter_rarity": "Odd"},
+            {"species": "Glamorose", "encounter_rarity": "Odd"},
+            {"species": "Stillroot", "encounter_rarity": "Rare"},
+        ],
     },
 }

--- a/data/pets.py
+++ b/data/pets.py
@@ -282,6 +282,7 @@ PET_DATABASE = {
         "species": "Mossling",
         "pet_type": "Grass",
         "rarity": "Common",
+        "classification_tier": "Ordinary",
         "personality": "Timid",
         "description": "A small, moss-covered creature that blends seamlessly into the forest floor. Its timid nature means it will flee at the first sign of danger, but it becomes surprisingly resilient when cornered.",
         "base_capture_rate": 45,
@@ -305,6 +306,7 @@ PET_DATABASE = {
                 "species": "Thornmoss",
                 "pet_type": ["Grass", "Rock"],
                 "rarity": "Uncommon",
+                "classification_tier": "Prime",
                 "description": "As Mossling matures, its soft coat hardens into a dense layer of moss-covered rock. Sharp thorns protrude from its back, and it carries itself with a quiet, unmovable confidence.",
                 "passive_ability": {
                     "name": "Thorn Guard",
@@ -326,6 +328,7 @@ PET_DATABASE = {
                         "species": "Ferngale",
                         "pet_type": ["Grass", "Rock"],
                         "rarity": "Rare",
+                        "classification_tier": "Apex",
                         "description": "An ancient, towering form wrapped in layers of living stone and cascading fern. Ferngale moves slowly but commands the battlefield with a primal authority — the forest itself seems to bend around it.",
                         "passive_ability": {
                             "name": "Ancient Growth",
@@ -352,6 +355,7 @@ PET_DATABASE = {
         "species": "Glimmerva",
         "pet_type": "Bug",
         "rarity": "Common",
+        "classification_tier": "Ordinary",
         "personality": "Timid",
         "description": "A soft-bodied, wingless larva covered in fine, glowing scales. It clings to sun-warmed leaves and bark, pulsing faintly with light when disturbed. Slow and harmless-looking, but the dust it sheds when threatened can be surprisingly disorienting.",
         "base_capture_rate": 50,
@@ -375,6 +379,7 @@ PET_DATABASE = {
                 "species": "Luminara",
                 "pet_type": ["Bug"],
                 "rarity": "Uncommon",
+                "classification_tier": "Prime",
                 "description": "Freshly emerged from its cocoon, Luminara's wings are still soft and unfolding, glimmering faintly even in shade. It moves in short, fluttering bursts, not yet trusting its new wings, but already drawn toward warmth and light.",
                 "passive_ability": {
                     "name": "Gilded Wings",
@@ -396,6 +401,7 @@ PET_DATABASE = {
                         "species": "Solarmoth",
                         "pet_type": ["Bug", "Fire"],
                         "rarity": "Rare",
+                        "classification_tier": "Apex",
                         "description": "Its metamorphosis complete, Solarmoth's wings have unfurled into great radiant fans that seem to burn with trapped sunlight. It glides rather than flutters now, leaving faint trails of warmth in the air, and even at night its wings continue to glow like embers.",
                         "passive_ability": {
                             "name": "Radiant Core",
@@ -420,6 +426,7 @@ PET_DATABASE = {
         "species": "Grimweave",
         "pet_type": ["Ghost", "Poison"],
         "rarity": "Uncommon",
+        "classification_tier": "Prime",
         "personality": "Aggressive",
         "description": "A shadowy, arachnid-like creature that weaves webs of Gloom-infused silk between the trees at night. Its presence makes the air feel cold and heavy, and the faint glow of its eyes is often the only warning before it strikes.",
         "base_capture_rate": 35,
@@ -445,6 +452,7 @@ PET_DATABASE = {
                 "species": "Duskspinner",
                 "pet_type": ["Ghost", "Poison"],
                 "rarity": "Rare",
+                "classification_tier": "Apex",
                 "description": "A larger, more terrifying form that wraps itself in a shroud of writhing Gloom-silk. Its eight limbs move with unsettling precision, and the webs it spins can trap both body and spirit.",
                 "passive_ability": {
                     "name": "Soul Snare",
@@ -466,6 +474,7 @@ PET_DATABASE = {
                         "species": "Veilmother",
                         "pet_type": ["Ghost", "Poison"],
                         "rarity": "Ancient",
+                        "classification_tier": "Elder",
                         "is_gloom_touched": True,
                         "gloom": {"state": "Hollow", "type": "Shrouded", "mark": "a vast, passive web-shroud — what's left of the self has emptied into something that only waits"},
                         "description": (
@@ -499,6 +508,7 @@ PET_DATABASE = {
         "species": "Moonwisp",
         "pet_type": ["Fairy", "Grass"],
         "rarity": "Uncommon",
+        "classification_tier": "Prime",
         "personality": "Tactical",
         "description": "A tiny, luminescent creature that dances among moonlit flowers in the depths of Whisperwood. Gentle by nature, it uses its fae magic to confound and disorient those who threaten its home rather than fighting directly.",
         "base_capture_rate": 35,
@@ -522,6 +532,7 @@ PET_DATABASE = {
                 "species": "Lunarblossom",
                 "pet_type": ["Fairy", "Grass"],
                 "rarity": "Rare",
+                "classification_tier": "Apex",
                 "description": "A graceful, flower-crowned being that radiates a soft silver light. It moves as if weightless, leaving a faint trail of glowing petals wherever it steps. Its fae magic has deepened into something ancient and difficult to resist.",
                 "passive_ability": {
                     "name": "Moonlit Grace",
@@ -545,6 +556,7 @@ PET_DATABASE = {
         "species": "Serpentine",
         "pet_type": ["Grass", "Dark"],
         "rarity": "Uncommon",
+        "classification_tier": "Prime",
         "personality": "Tactical",
         "description": "A slender, vine-like serpent that moves silently through the underbrush, its scales shifting between deep green and shadow depending on the light. It prefers to watch from cover for long stretches before ever striking.",
         "base_capture_rate": 35,
@@ -568,6 +580,7 @@ PET_DATABASE = {
                 "species": "Serpumbra",
                 "pet_type": ["Grass", "Dark"],
                 "rarity": "Rare",
+                "classification_tier": "Apex",
                 "description": "Serpentine's final form — a long, shadow-wreathed serpent whose scales seem to drink in the light around it. In dappled forest shade it can vanish almost entirely, becoming little more than a rustle in the leaves and a pair of watching eyes.",
                 "passive_ability": {
                     "name": "Living Camouflage",
@@ -591,6 +604,7 @@ PET_DATABASE = {
         "species": "Glamorose",
         "pet_type": ["Grass", "Poison"],
         "rarity": "Common",
+        "classification_tier": "Ordinary",
         "personality": "Tactical",
         "description": "A small, flower-headed creature with petals of an almost unnaturally vivid pink. Its sweet fragrance draws other creatures close — a little too close, and a little too often for it to be entirely accidental.",
         "base_capture_rate": 45,
@@ -614,6 +628,7 @@ PET_DATABASE = {
                 "species": "Malicea",
                 "pet_type": ["Grass", "Poison"],
                 "rarity": "Uncommon",
+                "classification_tier": "Prime",
                 "description": "Malicea's petals have unfurled wider and its fragrance grown richer — sweeter, even, the closer one gets to the soft rot at its core. Things that wander too near tend to linger longer than they mean to.",
                 "passive_ability": {
                     "name": "Sweet Decay",
@@ -635,6 +650,7 @@ PET_DATABASE = {
                         "species": "Aberraflora",
                         "pet_type": ["Grass", "Poison"],
                         "rarity": "Ancient",
+                        "classification_tier": "Elder",
                         "description": (
                             "The final form of the Glamorose line. A sprawling mass of bloom and "
                             "rot, half-buried in the deep Thicket where the canopy never quite "
@@ -666,6 +682,7 @@ PET_DATABASE = {
         "species": "Verdanthorn",
         "pet_type": ["Grass", "Normal"],
         "rarity": "Ancient",
+        "classification_tier": "Elder",
         "personality": "Defensive",
         "description": (
             "An ancient, towering presence at the heart of the Thicket — easy to mistake "
@@ -1356,13 +1373,36 @@ ENCOUNTER_TABLES = {
         "day": ["Corroder"],
         "night": ["Corroder", "Corroder", "Corroder", "Grimplate"]  # Grimplate ~25% — surfaces after dark
     },
+    # Encounter Rarity is relative to THIS location, not an intrinsic property
+    # of the species (see data/classifications.py — ENCOUNTER_RARITIES /
+    # ENCOUNTER_RARITY_WEIGHTS). Same species can read differently at
+    # different locations; Gloom-touched species are "Odd" in their home
+    # territory as a baseline for that signal to escalate elsewhere later.
     "whisperwoodGrove": {
-        "day": ["Mossling", "Mossling", "Glimmerva", "Glimmerva", "Verdanthorn"],   # Verdanthorn ~20% — ancient, rare sighting
-        "night": ["Mossling", "Mossling", "Grimweave", "Moonwisp", "Glamorose", "Glamorose", "Malicea"]  # Malicea ~14% — low-chance evolution
+        "day": [
+            {"species": "Mossling", "encounter_rarity": "Normal"},
+            {"species": "Glimmerva", "encounter_rarity": "Normal"},
+            {"species": "Verdanthorn", "encounter_rarity": "Rare"},  # Elder tier, ancient/rare sighting
+        ],
+        "night": [
+            {"species": "Mossling", "encounter_rarity": "Normal"},
+            {"species": "Glamorose", "encounter_rarity": "Normal"},
+            {"species": "Grimweave", "encounter_rarity": "Odd"},  # Gloom-touched
+            {"species": "Moonwisp", "encounter_rarity": "Odd"},
+            {"species": "Malicea", "encounter_rarity": "Odd"},
+        ],
     },
     "whisperwoodWilds": {
-        "day": ["Mossling", "Mossling", "Serpentine"],
-        "night": ["Mossling", "Serpentine", "Serpentine", "Grimweave", "Serpumbra"]  # Serpumbra ~20% — low-chance evolution
+        "day": [
+            {"species": "Mossling", "encounter_rarity": "Normal"},
+            {"species": "Serpentine", "encounter_rarity": "Odd"},
+        ],
+        "night": [
+            {"species": "Serpentine", "encounter_rarity": "Normal"},
+            {"species": "Mossling", "encounter_rarity": "Odd"},
+            {"species": "Grimweave", "encounter_rarity": "Odd"},  # Gloom-touched
+            {"species": "Serpumbra", "encounter_rarity": "Odd"},  # Apex-tier evolution, uncommon at night
+        ],
     },
     "ashenVerge": {
         # The Ash Circle — Tindertail intentionally absent (Bram & Pip's shared

--- a/data/pets.py
+++ b/data/pets.py
@@ -921,7 +921,7 @@ PET_DATABASE = {
     # -------------------------------------------------------------------------
 
     "Stillroot": {
-        "species": "Stillroot", "pet_type": ["Rock", "Grass"], "rarity": "Common", "classification_tier": "Ordinary",
+        "species": "Stillroot", "pet_type": ["Rock", "Grass"], "rarity": "Common", "classification_tier": "Apex",  # bumped from Ordinary so its unique Stonecrust passive isn't overridden by the shared pool — fits its Gloom-marked, Rare-sighting status at the Weeping Root
         "personality": "Steadfast",
         "is_gloom_touched": True,
         "gloom": {"state": "Touched", "type": "Calcifying", "mark": "patches of genuine stone-like growth across the body, stalled in place"},

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,69 @@
+# Aethelgard — Design Docs
+
+This folder is the working collection of world/story design for Aethelgard — brainstorm
+output shared between brainstorm sessions, code sessions, and Kyle. It's notes and
+scaffolding, not user-facing documentation. Whether/when any of this gets committed is a
+separate call — these files exist to keep ideas consistent across sessions, first.
+
+---
+
+## Folder Structure
+
+```
+docs/design/
+  README.md                  <- this file
+  world/                      World-level frameworks — apply across all remnants/towns
+    aethelgard_classification.md
+    aethelgard_gloom_frames.md
+    aethelgard_world_connections.md
+  <remnant_name>/             One folder per town/remnant
+    <remnant_name>.md          Core design doc (NPCs, pets, locations, lore, items)
+    <quest_name>_quest.md      Main story / quest line for that remnant (story-first pass)
+    archive/                    Superseded versions of docs in this folder
+```
+
+Currently:
+- `world/` — classification & rarity system, the Seven Gloom States philosophy/frames,
+  and cross-remnant connection threads.
+- `oakhaven_outpost/` — tutorial hub. Tagged `-done` (see Conventions).
+- `weeping_chasm/`, `mirefields/`, `whisperwood_grove/` — each has a core design doc +
+  main quest doc, in active development.
+
+---
+
+## Conventions
+
+- **Story first, mechanics/wiring later.** Quest docs are written as narrative spines
+  (beats, branches, NPC side stories) before objective types/quest IDs/dialogue keys are
+  finalized. "What Exists in Code Today" sections in each quest doc track the gap.
+- **`-done` / `-implemented` suffix** — a filename tag (not a folder) meaning "this
+  remnant's design is fully wired in code, no open implementation questions remain."
+  Currently only `oakhaven_outpost-done.md`. Untagged = still has open questions/pending
+  wiring per that doc's own "Open Questions"/"Implementation Notes" sections.
+- **`archive/`** — superseded versions of a doc, kept for history/context. The current
+  doc states what it supersedes (e.g. `weeping_chasm_v2.md` supersedes
+  `archive/weeping_chasm.md`).
+- **`LOCKED` status** (noted at the top of most docs) — the brainstorm/decisions in that
+  doc are settled for now. Doesn't mean "never revisit," just "don't re-litigate without a
+  reason — build on this."
+- **Cross-references** — docs link to each other by filename (e.g.
+  `` `whisperwoods_plea_quest.md` ``). These are informal pointers for readers, not
+  resolved paths — use folder structure above + filename to locate.
+- **Some docs are explicitly "don't edit further"** (e.g. `whisperwood_grove.md` is a
+  checkpoint — new lore that touches it goes into newer docs instead, with a note
+  cross-referencing back). If a doc says this, respect it; add a new doc or section
+  elsewhere rather than editing in place.
+
+---
+
+## Reading Order (suggested, for getting oriented)
+
+1. `world/aethelgard_classification.md` — Classification Tier / Encounter Rarity / Gloom
+   States. The shared vocabulary everything else uses.
+2. `world/aethelgard_gloom_frames.md` — philosophy/factions pass (work in progress).
+3. Per-remnant core doc (e.g. `whisperwood_grove/whisperwood_grove.md`) for that
+   remnant's NPCs/lore.
+4. Per-remnant quest doc (e.g. `whisperwood_grove/whisperwoods_plea_quest.md`) for the
+   story spine built on top of the core doc.
+5. `world/aethelgard_world_connections.md` last — ties remnants together once you know
+   what's in each.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -28,6 +28,9 @@ Currently:
 - `oakhaven_outpost/` — tutorial hub. Tagged `-done` (see Conventions).
 - `weeping_chasm/`, `mirefields/`, `whisperwood_grove/` — each has a core design doc +
   main quest doc, in active development.
+- **Ashen Verge and Weeping Root don't have their own folders** — they're covered as
+  sub-regions inside `whisperwood_grove/whisperwood_grove.md` (Bram & Pip, Corvin,
+  Elowen, etc. all live there). If you're looking for them, start there.
 
 ---
 

--- a/docs/design/mirefields/mirefields_main_quest.md
+++ b/docs/design/mirefields/mirefields_main_quest.md
@@ -1,0 +1,244 @@
+# Mirefields — Main Story (Story Pass)
+
+**Status:** LOCKED (brainstorm session, no code changes yet)
+
+Same approach as `echoes_from_below_quest.md` and `whisperwoods_plea_quest.md`: **story
+first, mechanics/wiring later.** This is Mirefields' main story — the second stop on the
+Oakhaven → Weeping Chasm → Mirefields → Whisperwood road.
+
+---
+
+## What Exists in Code/Docs Today
+
+- `mirefields.md` — full design doc. Sable (NPC, shop, dialogue) and Ferryn (seasonal NPC)
+  both fully written. Old Crossroads = environmental lore + standalone Choice Event
+  (`waystation_ledger`). "Ferryn's Fetch" quest stubbed (retrieve `ferryn_equipment` near
+  the crossroads boundary, return to Ferryn) — currently a simple two-step fetch, not yet
+  connected to the Old Crossroads beat.
+- `data/towns.py` / `mirefields.md` "UI Layout" — **no travel gate either direction.**
+  Back to Weeping Chasm always open; forward to Whisperwood Grove is "open road" with no
+  requirement. This is intentional and should stay that way — see Framing below.
+- Currently *not* connected: Ferryn's Fetch and the Old Crossroads ledger are two separate
+  pieces of content that happen to be near each other geographically but don't reference
+  each other.
+
+---
+
+## Framing — "The Place That Let Go"
+
+Mirefields is explicitly the odd one out so far: `gloom_level: 8`, "the danger here is
+physical, not supernatural," Siltborn/Mirewarden are **not** Gloom-touched — "the mire's
+wrongness is ancient and organic." Whisperwood and Weeping Chasm are both, in different
+ways, stories about *escalating* wrongness and a search for understanding. Mirefields
+isn't that, and shouldn't try to be.
+
+**The story here is smaller and more human-scale on purpose:** a place that used to matter,
+and the two people who stayed after everyone else left — for opposite reasons (Sable wants
+it to stay forgotten; Ferryn wants to understand why it's changing). The "main story" is
+really about **the player walking into that disagreement**, briefly, without needing to
+resolve it.
+
+This also means:
+- **No travel gate.** Unlike `echoes_from_below` (which required a quest-flag to unlock
+  Weeping Chasm's connection), Mirefields' road stays open in both directions regardless of
+  whether the player engages with any of this. "The mire won, but the road's still here if
+  you want to use it" — apt for a place defined by indifference, not danger.
+- **The Deep Mire / Mirewarden / "Probably" threads (per `mirefields.md`'s "Lore Thread —
+  The Deep Mire" and `aethelgard_world_connections.md`'s "Probably") stay exactly as
+  ambiguous as they currently are.** This story pass should *touch* that ambiguity (the
+  player gets close enough to feel the Mirewarden's territory, per the existing "tense, not
+  dangerous" design) without resolving anything. Same "no solution yet" discipline as the
+  other two remnants, just with lower stakes.
+
+---
+
+## Quest Structure Note
+
+Given no travel gate, the main story here is best framed as an **optional `side`-type
+quest** (per `data/quests.py`'s type vocabulary: "Optional NPC quest, completable anytime")
+rather than an `assignment` or `main` quest. It still gets full objectives in the quest tab
+for players who pick it up — it just never blocks anything if ignored.
+
+**Proposed unification:** fold the existing "Ferryn's Fetch" stub and the standalone Old
+Crossroads ledger Choice Event into **one quest arc** — they're a few minutes' walk from
+each other and thematically the same beat (both involve getting close to the Mirewarden's
+territory). Working title: **"Readings from the Edge"** (placeholder, easy to rename).
+
+---
+
+## Story Spine (Beats)
+
+- **Beat 1 — Sable's Camp.** Arrival. Existing `default`/`night` dialogue and shop. First
+  impression of Mirefields: economical, indifferent, *fine*. Nothing needs fixing here —
+  that's the point.
+
+- **Beat 1.5 — The Trail Markers (stretch).** Existing flavor event: Sable's knotted-reed
+  trail markers are the only reliable guide through the mire. A small, wordless
+  characterization beat — she maintains this for travelers she's not particularly
+  interested in meeting. Nobody asked her to. She just does.
+
+- **Beat 2 — The Reed Hollow / Ferryn.** Meet Ferryn (if in season). Her enthusiasm,
+  `lore_expansion`, `about_sable` — the tension between the two of them surfaces naturally,
+  without the player needing to take a side.
+
+- **Beat 2.5 — Silt's Unease (stretch).** Small observational beat, drawn from existing
+  Ferryn lore: Silt (her Pallefin) reacts to certain water near the expanding sections —
+  refuses to enter, gets agitated near the crossroads area. Ferryn's noted it, hasn't
+  concluded anything. Plant, don't explain.
+
+- **Beat 3 — Ferryn's Request (existing "Ferryn's Fetch").** Retrieve `ferryn_equipment`
+  near the crossroads boundary — "tense, not dangerous," per existing design. First brush
+  with Mirewarden territory: the player feels it without seeing it.
+
+- **Beat 3.5 — The Readings (stretch).** Return the gauge. Ferryn's `quest_complete`
+  reaction — the readings near that area are "unlike anything else in the mire." She files
+  it and moves on, same restraint Kael showed post-Chasmbane in `echoes_from_below`. Small
+  but deliberate echo between the two remnants' scholars.
+
+- **Beat 4 — The Old Crossroads (Climax, such as it is).** The existing Choice Event:
+  overgrown foundations, the illegible signpost, fresh territorial signs, the sealed
+  ledger. "Take the ledger" / "Step back" — exactly as currently designed. This is the
+  closest the player gets to the Mirewarden, and the design intent (unease, not combat)
+  stays unchanged.
+
+- **Beat 4.5 — Showing Sable (stretch, conditional on taking the ledger).** New small
+  beat: bring the `waystation_ledger` to Sable. She doesn't need to read it — she already
+  knows what it'll say. `lore_crossroads`-adjacent reaction: *"Figured something like that
+  was still down there. Didn't go looking."* Not dismissive — just confirms she's known
+  about that section longer than the player has, and chose not to engage with it, same as
+  she's chosen not to engage with Ferryn's research. Reinforces her character without new
+  plot.
+
+- **Beat 5 — The Road Continues.** No formal "coda" turn-in needed beyond Beat 3.5/4.5 —
+  the quest can simply complete on returning the gauge (Beat 3.5), with the Old Crossroads
+  beat (4/4.5) as connected-but-optional bonus content for players who want to go further.
+  Either way, the player continues toward Whisperwood at their own pace. Open road, as
+  designed.
+
+---
+
+## Objective Mapping Notes (for future mechanics pass)
+
+| Beat | Likely objective type(s) |
+|---|---|
+| 1 | `talk_npc` → Sable (optional, flavor) |
+| 1.5 | none — pure flavor event |
+| 2 | `talk_npc` → Ferryn (quest start, if in season) |
+| 2.5 | none — pure flavor/dialogue |
+| 3 | `item_pickup` → `ferryn_equipment`, `zone: mirefields` (quest-only Choice Event, existing) |
+| 3.5 | `talk_npc` → Ferryn (turn in gauge) — **quest may complete here** |
+| 4 | optional — Old Crossroads Choice Event, `item_pickup` → `waystation_ledger` if taken (not currently quest-gated; could remain free-standing OR become an optional bonus objective) |
+| 4.5 | optional — `talk_npc` → Sable, only if `waystation_ledger` in inventory |
+| 5 | none — no turn-in, just onward travel |
+
+**Key design question carried into Open Questions:** should Beat 4 (the ledger) be part of
+this quest's objectives at all, or stay a fully free-standing Choice Event that *happens*
+to sit near Beat 3's location? Leaning toward: **keep it free-standing**, but add Beat 4.5
+(Sable reaction) as a small bonus dialogue branch that fires *if* the player has the ledger,
+regardless of quest state. Keeps the "open, optional, low-pressure" feel intact.
+
+---
+
+## Branches — Side Stories (rough sketches)
+
+Same as `echoes_from_below_quest.md`: **purely optional**, none gate the (already
+gate-free) road. With only two NPCs, this is short — and that's fine.
+
+### Branch 1 — "The One Who Stayed" (Sable, affinity-based)
+
+- Affinity-unlocked, gradual, same pattern as Whisperwood/Weeping Chasm's affinity NPCs.
+- **The shape of it:** deepens what's already in `mirefields.md` — growing up on the edge
+  of the mire when the crossroads was active, learning it "the way you learn a language
+  when you're a child," and the quiet realization after the waystation collapsed that the
+  emptied-out version of this place was the one she'd actually wanted all along.
+- **Tone:** no tragedy, no reveal. Just Sable, in her economical way, confirming what the
+  player has probably already pieced together by Beat 1.5 (the trail markers) — she didn't
+  stay out of stubbornness or grief. She stayed because everyone else leaving solved a
+  problem she'd had her whole life.
+- **Possible late beat:** if the player has built enough affinity *and* brought her the
+  `waystation_ledger` (Beat 4.5), one additional line becomes available — she recognizes a
+  name or route in the ledger from her childhood. Doesn't react visibly. Just: *"Huh."*
+  Doesn't elaborate. (Optional connection to "What the Ledger Knew" — see below.)
+- **Reward:** none — pure characterization.
+
+### Branch 2 — "Probably" (Ferryn, seasonal arc)
+
+- Uses the seasonal mechanic already designed in `mirefields.md` — no new system needed.
+- **In-season (Before):** Beats 2/2.5/3/3.5 as written in the main spine — Ferryn's
+  optimism, Silt's unease, the gauge retrieval, her restrained-but-intrigued reaction to
+  the readings.
+- **Off-season / "she's gone" (During → After):** per existing design, the Reed Hollow is
+  empty when the player returns at higher rank, except for her field notes left on the
+  post. This branch's addition: the notes' final entry — the one that "reads like she got
+  closer to the crossroads than she told Sable she would" — should specifically reference
+  **the readings from Beat 3.5** as the reason she went back. Not a cliffhanger sequence,
+  just one consistent thread: the gauge readings near the crossroads were "unlike anything
+  else in the mire," and that's exactly the kind of thing Ferryn wouldn't be able to leave
+  alone.
+- **This is the direct payoff of "Probably"** in `aethelgard_world_connections.md` — the
+  structural echo to Anora (researcher gets close to something Gloom-adjacent-or-not, goes
+  further than told, doesn't come back, fate left ambiguous). For a player who's done
+  `whisperwoods_plea` first, finding Ferryn's notes should land with quiet recognition —
+  *I've seen this shape before.* For a player who hasn't, it's just an unresolved local
+  mystery, which is fine — same order-independence approach as `echoes_from_below`.
+- **Reward:** none — this is the emotional/connective payoff, not a mechanical one.
+
+### Branch 3 — "The Crossroads Trade" (connection only, Ashen Verge)
+
+- Not a Mirefields NPC story — this is the Mirefields-side half of "The Crossroads Trade"
+  from `aethelgard_world_connections.md` (Bram & Pip, Ashen Verge).
+- **Implementation:** a small addition to Sable's existing `lore_crossroads` dialogue —
+  when describing the crossroads' busy days, she can mention the kind of traders who came
+  through: *"Salvagers, mostly, this end. People who picked through old ruins further out
+  and brought it here to sell on."* Doesn't name Bram & Pip — just establishes that the
+  *kind* of trade Bram & Pip do today is the same kind that used to flow through here.
+- **Payoff sits on the Ashen Verge side** (Bram/Pip's affinity line about the crossroads
+  drying up, per the connections doc) — this branch is just the matching half-sentence on
+  the Mirefields end, so neither side needs the other to make sense, but together they
+  quietly confirm the same economic history from two unconnected NPCs.
+- **Reward:** none — pure world-texture.
+
+---
+
+## NPC Personal Side Stories — Mapping
+
+| NPC | Personal side story |
+|---|---|
+| Sable | Branch 1 — "The One Who Stayed" |
+| Ferryn | Branch 2 — "Probably" |
+
+(Branch 3 is a connection-only addition to Sable's existing dialogue, not a separate
+personal story.)
+
+---
+
+## Open Questions
+
+1. Quest type/name — "Readings from the Edge" is a placeholder. Could also just keep
+   "Ferryn's Fetch" as the formal quest and treat Beats 4/4.5 as unrelated bonus content
+   (per the leaning above) — in which case this doc is really "Ferryn's Fetch, expanded
+   with surrounding flavor beats" rather than a brand-new quest.
+2. Reward for the gauge-retrieval — original stub said TBD + "Ferryn's expansion lore
+   dialogue unlocks fully." Suggest keeping it lore-only, consistent with
+   `echoes_from_below`'s "this is about information, not loot" precedent.
+3. Branches/side stories (Sable's deeper history, the Sable/Ferryn dynamic over time,
+   "The Crossroads Trade" connection to Ashen Verge, "Probably"/Ferryn's departure) —
+   not started yet. Next pass.
+4. Should there be any small connective nod *from* Weeping Chasm (Kael or Gretta
+   mentioning the mire ahead) the way Galen's line seeds `echoes_from_below`? Leaning:
+   not necessary — Mirefields doesn't need a "tutorial exit" moment the way Oakhaven did,
+   and the open-road design already signals "just pass through if you want."
+
+---
+
+## Cross-References
+
+- `mirefields.md` — full design doc (NPCs, pets, items, explore events, Old Crossroads,
+  Lore Thread — The Deep Mire).
+- `echoes_from_below_quest.md` — structural precedent (story spine + stretch beats +
+  objective mapping), Kael's restraint as a model for Ferryn's `quest_complete` beat.
+- `aethelgard_world_connections.md` — "Probably" (Ferryn ↔ Anora structural echo), "What
+  the Ledger Knew" (Whisperwood ↔ Mirefields, `waystation_ledger`), "The Crossroads Trade"
+  (Ashen Verge ↔ Mirefields, Bram & Pip).
+- `aethelgard_classification.md` — relevant by *contrast*: Siltborn/Mirewarden are
+  explicitly outside this framework (not Gloom-touched).

--- a/docs/design/weeping_chasm/echoes_from_below_quest.md
+++ b/docs/design/weeping_chasm/echoes_from_below_quest.md
@@ -1,0 +1,291 @@
+# echoes_from_below — Quest Line (Story Pass)
+
+**Status:** LOCKED (brainstorm session, no code changes yet)
+
+Same approach as `whisperwoods_plea_quest.md`: **story first, mechanics/wiring later.**
+This is Weeping Chasm's main story — the "first stop after Oakhaven." It also exists to
+make Aethelgard feel connected: see `aethelgard_world_connections.md` for the cross-remnant
+threads this sets up ("The Threnody Correspondence," "The Long Memory").
+
+---
+
+## What Exists in Code Today
+
+- `data/towns.py` — Oakhaven's `connections` include `weeping_chasm`, gated by
+  `connection_requirements: { "weeping_chasm": "quest_a_guildsmans_first_steps_completed" }`.
+  Comment in code confirms the intended route: **Oakhaven → Weeping Chasm → Mirefields →
+  Whisperwood.**
+- `data/quests.py` — `a_guildsmans_first_steps` (main quest, Oakhaven) auto-grants
+  `head_to_whisperwood` (assignment: "Travel to Whisperwood Grove") on completion. Both are
+  fully implemented.
+- `weeping_chasm_v2.md` — `echoes_from_below` exists only as a rough stub: "Giver: Elder
+  Vexia (Oakhaven Outpost)... reward TBD... forward hook to Obsidian Monoliths/Sunstone
+  Oasis." Written before Whisperwood Grove existed — Vexia is actually in Whisperwood, not
+  Oakhaven, so this stub needs reframing (see below).
+- `weeping_chasm_v2.md` — Kael already has a `required_quest` gate wired in code (data
+  not yet written). Orin, Kael, Gretta all have base dialogue implemented.
+- `docs/design/oakhaven_outpost/oakhaven_outpost-done.md` — Galen's Vigil: Galen suspects "the Rotting Pits
+  and the Weeping Chasm share a Gloom source — same breach, different surface points," but
+  doesn't file reports. Lore-only, no quest wrapper currently.
+
+---
+
+## Reframe — Giver & The Oakhaven Handoff
+
+**Old plan:** Vexia (Oakhaven) gives the quest, sends player to Weeping Chasm, player
+returns to Vexia. Doesn't work — Vexia's in Whisperwood, and it creates an awkward
+backtrack right at the moment the player is supposed to be heading *forward*.
+
+**New plan:**
+- **`echoes_from_below` is given on-site by Lore-Keeper Kael**, at the Scholar's Camp,
+  Weeping Chasm — the first NPC with anything substantial to say once the player leaves
+  Oakhaven. No round trip needed. The quest resolves entirely within Weeping Chasm
+  (return to Kael, not to anyone in Oakhaven).
+- **The Oakhaven Handoff** is a single added dialogue line, not a new objective — flavor
+  only, attached to the completion of `a_guildsmans_first_steps` (or `head_to_whisperwood`'s
+  flavor text). Spoken by **Grit Galen**, since he's the one with the Gloom-source theory:
+
+  > *"The road to Whisperwood runs through the Weeping Chasm first. Guild keeps a scholar
+  > out there — Kael. Good man, bit obsessive. He's been cataloguing things out there for
+  > years. If the Pits and the Chasm really do share a source like I think... he's the one
+  > who'd want to know what you've seen here."*
+
+  This does three things at once: hands the player forward naturally, gives Galen's
+  unfiled theory somewhere to *go* (without Galen ever leaving Oakhaven), and gives Kael a
+  reason to be receptive to the player immediately — he's expecting someone, in a sense,
+  even if not literally.
+
+- **Net result:** Oakhaven stays "done" — no new objectives added there, no quest reopened.
+  Just one new line of dialogue on an already-completed quest's tail end.
+
+---
+
+## Lore Update — The Chasm as a Wider Question
+
+`Kael's `lore_gloom_origin` (his theory: "the Chasm" as a singular Gloom breach point,
+rooted in collective grief) sits in tension with Whisperwood's **Unified Origin** (one
+organism, two surface points, grown from Sylven's roots — see `whisperwoods_plea_quest.md`).
+Both can't be the *whole* picture, and `echoes_from_below` doesn't need to resolve that —
+in fact it shouldn't, yet.
+
+**Framing:** a player who's finished `whisperwoods_plea` already feels like they understand
+the shape of "the problem." `echoes_from_below` is where that shape gets **wider, not
+clearer**. Maybe Kael's "single breach" theory isn't wrong — maybe the Chasm is older and
+deeper than the Whisperwood situation, and what happened at Whisperwood is something that
+*grew out of* a connection the Chasm still has. This lines up with
+`aethelgard_classification.md`'s note that the Chasm is "a strong candidate for a future
+Primordial/Eternal-tier entity" — bigger than any single Elder pair.
+
+Same spirit as the Unified Origin: **nobody to blame, no solution yet, just a wider view.**
+This sets up future arcs (Mirefields' Deep Mire, eventual Primordial/Eternal reveals)
+without committing to any of them now.
+
+**Order independence note:** Some players may reach Weeping Chasm having *not yet* done
+Whisperwood's plea (it's earlier on the route). That's fine — `echoes_from_below` stands on
+its own without referencing Whisperwood by name. The "widening" framing only *lands harder*
+in retrospect for players who do both, in either order. Nothing here should require
+`whisperwoods_plea` as a prerequisite.
+
+---
+
+## Story Spine (Beats)
+
+- **Beat 1 — Arrival at the Chasm's Edge.** Player arrives via the Oakhaven→Chasm route
+  (Galen's handoff line already primed them for Kael). First atmosphere beat: the cold,
+  the slow exhale-rhythm from below, Warden Orin's quiet vigilance at the Edge.
+
+- **Beat 1.5 — The Tally Marks (stretch).** The cracked Guild marker post with 37 scratched
+  tally marks (already an existing flavor event). Small optional beat: ask Orin about it —
+  he doesn't know either. Plants "nobody's been counting on purpose, but somebody's been
+  counting" without explanation.
+
+- **Beat 2 — Kael, Scholar's Camp.** Quest given here (reframed giver). Kael explains the
+  samples task, but also — almost as an aside — his `lore_hollowed_vs_corrupted`
+  distinction. Sets vocabulary the way Elowen/Corvin did for Whisperwood, but from a
+  scholar's remove rather than personal grief.
+
+- **Beat 2.5 — Threnody (stretch).** A quiet character beat: Kael's Duskspinner,
+  "Threnody." If asked, Kael explains the name (a funeral song, referencing the Gloom's
+  origin in collective sorrow) — existing dialogue hook. Establishes Kael as someone who's
+  been quietly carrying this question for a long time, before anything's gone wrong yet.
+
+- **Beat 3 — The East Wall / Collecting Samples.** Chasm's Edge explore proper — hazard
+  events, the Veilmother webbing sighting (existing Pet Sighting event). Orin's
+  `lore_east_wall` line lands here ("something large made that overnight, I don't go near
+  it").
+
+- **Beat 3.5 — Gretta's Hollow (stretch).** Visit Gretta's camp. The Threshling is *seen*,
+  not explained — Gretta's philosophy ("It isn't [named]"). A quiet, unsettling character
+  beat before the climax. (This is also the seed for "The Long Memory" — see
+  `aethelgard_world_connections.md`.)
+
+- **Beat 4 — The Breathing (Climax).** Samples collected, but the Chasm reacts — the
+  **Chasmbane scare encounter** (per the rank-gated design in `weeping_chasm_v2.md`):
+  Gloom Meter spike, forced retreat, no battle UI. Not a fight to win — a moment to survive
+  and walk away from, recontextualizing every hint since Beat 1.
+
+- **Beat 4.5 — The Quiet After (stretch).** Back at Scholar's Camp, shaken. Kael doesn't
+  have words either — possibly the first time the player sees him *not* immediately reach
+  for a theory. Mirrors Whisperwood's "Quiet After" beats.
+
+- **Beat 5 — Return to Kael, the Theory Widens.** Samples delivered. `lore_gloom_origin`
+  delivered properly here, with the "widening" framing from the Lore Update above.
+
+- **Beat 5.5 — Forward Hook (stretch).** Kael's forward hook to Obsidian Monoliths/Sunstone
+  Oasis (per existing stub) — kept light, a "there's more out there" beat rather than a
+  hard quest chain commitment.
+
+- **Beat 6 — Coda.** Quest closes at Weeping Chasm itself — no Oakhaven or Whisperwood
+  return trip required. Player continues forward toward Mirefields/Whisperwood at their
+  own pace, quest fully resolved.
+
+This is 6 numbered beats + 4 stretch beats — slightly leaner than Whisperwood's 11, which
+fits: this is a tutorial-adjacent "first taste of the open world," not a town's full plea
+quest.
+
+---
+
+## Objective Mapping Notes (for future mechanics pass)
+
+Following `a_guildsmans_first_steps` / `head_to_whisperwood` conventions, each beat above
+should map to a quest-tab objective using existing types:
+
+| Beat | Likely objective type(s) |
+|---|---|
+| 1 | `talk_npc` → Orin (arrival flavor, optional) |
+| 1.5 | optional, may not need an objective — pure flavor/Choice Event |
+| 2 | `talk_npc` → Kael (quest start) |
+| 2.5 | optional flavor, no objective needed |
+| 3 | `item_pickup` → `gloom_mist_sample` x3, `zone: weeping_chasm` (Chasm's Edge) |
+| 3.5 | optional, `talk_npc` → Gretta (flavor, not required) |
+| 4 | scare encounter — likely needs a new objective type or a flag-based trigger;
+    flag for implementation review (same as the rank-gating tag already in
+    `weeping_chasm_v2.md`) |
+| 4.5 | optional flavor |
+| 5 | `talk_npc` → Kael (turn in samples) |
+| 5.5 | dialogue-only, no objective |
+| 6 | none — quest completes on Beat 5's turn-in |
+
+This keeps the "don't get lost" guarantee — every required step has a visible objective —
+while letting the stretch beats stay purely textual, same balance as Whisperwood's.
+
+---
+
+## Branches — Side Quests & Side Stories (rough sketches)
+
+All of the below are **purely optional** — none gate `echoes_from_below`'s completion or
+the player's onward journey toward Mirefields/Whisperwood. They exist for players who
+linger, the way Whisperwood's branches did. Same Before/During/After stretch structure
+where it fits.
+
+### Branch 1 — "The Sealed Journal" (feeds The Threnody Correspondence)
+
+- **Before:** During Beat 3 (Chasm's Edge explore), the existing Choice Event — a sealed
+  Guild journal wedged near the Tainted Ledge — fires. "Pry it open" gives `lore_fragment`
+  (minor Gloom-meter risk, per existing design). Player may or may not take it.
+- **During:** If the player has `lore_fragment` and talks to Kael (any time after Beat 2),
+  new dialogue: Kael recognizes the handwriting immediately — it's his own, from years ago.
+  It's a copy of a letter he sent to "an archivist in Whisperwood" (Linden, unnamed at this
+  point) asking whether anyone had records of Guild scouts who went missing near
+  Gloom-sources and were later "accounted for, but changed." He never got a real answer.
+- **After:** Kael asks the player, almost offhand, to mention it if they ever pass through
+  Whisperwood and meet "whoever keeps the records there now." No quest flag forced — just
+  a planted thread. **This is the direct seed for "The Threnody Correspondence"** in
+  `aethelgard_world_connections.md`: if the player later reaches Linden's capstone reveal in
+  `whisperwoods_plea_quest.md`, Linden's old reply-that-was-never-followed-up takes on extra
+  weight, and the player has *both halves* of a conversation two NPCs never finished.
+- **Reward:** `lore_fragment` (existing item). No mechanical reward beyond that — this is an
+  information/connection branch.
+
+### Branch 2 — "What Spun That" (Veilmother thread)
+
+- **Before:** During Beat 3, Orin's `lore_east_wall` line ("the east wall is webbed over
+  some mornings... I don't go near it") plants the hook.
+- **During:** Optional return visit to the Chasm's Edge after Beat 3 — a new flavor/Choice
+  Event variant: the webbing is closer to the path than it was. Something small is caught
+  in it — too far away and too high to identify clearly. "Look closer" vs. "Leave it."
+  Looking closer doesn't resolve anything (no item, no battle) — just a slightly-too-long
+  description of *almost* making out a shape, before the player's pet pulls them back.
+- **After:** If the player mentions this to Orin, his only reaction: *"Then you've seen as
+  much as I have. Don't go back for a better look."* No new lore unlocked — the dread is
+  the content. This deliberately stays unresolved; Veilmother remains a Wanderer-rank
+  scare/Legend-rank theoretical capture per `weeping_chasm_v2.md`'s existing rank-gating.
+- **Reward:** None — pure atmosphere/foreshadowing branch.
+
+### Branch 3 — "Held at the Threshold" (Gretta's Threshling, feeds The Long Memory)
+
+- **Before:** Beat 3.5 (Gretta's Hollow) — the Threshling is seen for the first time,
+  unexplained.
+- **During:** Optional follow-up conversation with Gretta (`subdue_path_intro` dialogue
+  already exists per code state) — she explains her philosophy of the Subdue capture path
+  using the Threshling as the example: *"Didn't purify it. Made it clear who's in charge.
+  That's all Subdue ever is — an agreement about who yields first."* This doubles as a
+  natural-language introduction to the Subdue mechanic for players who haven't encountered
+  it yet.
+- **After:** A small, quiet detail — if the player lingers, the Threshling's clear eye
+  tracks them, briefly, before going still again. Gretta, without looking up: *"It does
+  that. Don't read into it."* Plants unease without explanation.
+- **Connection payoff (later, elsewhere):** This is the direct seed for **"The Long
+  Memory"** in `aethelgard_world_connections.md` — when/if Corvin's affinity story (Weeping
+  Root) deepens, his offhand recognition of "something held at a threshold, out east" lands
+  for any player who's been here. No forced ordering; works whichever remnant comes first.
+- **Reward:** None mechanically — characterization + Subdue-mechanic teaching moment +
+  cross-remnant seed.
+
+### Branch 4 — Orin's Posting (affinity-based)
+
+- Light, affinity-unlocked personal background for Warden Orin, gradually revealed over
+  repeated conversations (same unlock pattern as Whisperwood's affinity-based NPC stories).
+- **The shape of it:** Orin started out as a Guild recruit at Oakhaven, much like the
+  player — and at some point, instead of moving on toward Whisperwood (or wherever his
+  "head to ___" assignment pointed), he stayed at the Chasm. Not because of a dramatic
+  event — he just... didn't leave. His Barkback (evolved from a Pineling issued early in
+  his posting) is the only thing that's changed since.
+- **Why it matters:** offers a quiet "road not taken" mirror for the player, who *is*
+  currently mid-journey on that same road. Doesn't need a tragic reason — "I got used to
+  the cold air. Didn't anymore. Stayed." is enough. Could gently echo Corvin's "stayed near
+  the wound for decades" framing from Weeping Root, without copying it — Orin stayed near
+  *nothing happening*, which is its own kind of staying.
+- **Reward:** None — pure characterization.
+
+---
+
+## NPC Personal Side Stories — Mapping
+
+Unlike Whisperwood (large cast, dedicated section needed), Weeping Chasm has only three
+NPCs — and each is already covered by a Branch above. No separate content needed; this is
+just a pointer for consistency with `whisperwoods_plea_quest.md`'s structure:
+
+| NPC | Personal side story |
+|---|---|
+| Warden Orin | Branch 4 — "Orin's Posting" |
+| Lore-Keeper Kael | Branch 1 — "The Sealed Journal" |
+| "Grim" Gretta | Branch 3 — "Held at the Threshold" |
+
+---
+
+## Open Questions
+
+1. Reward for `echoes_from_below` — original stub said "TBD." Suggest: XP + a lore item
+   (mirrors `lore_fragment` already planned) rather than a pet/equipment reward, to keep
+   tone consistent (this quest is about *information*, not loot).
+2. Beat 4's scare encounter as a quest objective — needs an implementation-feasibility
+   check (carried over from `weeping_chasm_v2.md`'s existing TAG FOR IMPLEMENTATION REVIEW).
+3. Branches/side quests and NPC personal side stories for Weeping Chasm — not started yet;
+   next pass, same structure as Whisperwood (Branches → NPC Personal Side Stories).
+4. Should Galen's handoff line be conditional on anything, or always shown? Leaning: always
+   shown, since it's flavor-only and doesn't gate progress.
+
+---
+
+## Cross-References
+
+- `weeping_chasm_v2.md` — full Weeping Chasm design (NPCs, pets, Apex Ancients, explore
+  events, original `echoes_from_below` stub).
+- `whisperwoods_plea_quest.md` — Unified Origin lore, story-spine precedent, NPC Personal
+  Side Stories structure to follow for Weeping Chasm's next pass.
+- `aethelgard_classification.md` — Classification Tier framework; Primordial/Eternal note.
+- `aethelgard_world_connections.md` — "The Threnody Correspondence" (Kael ↔ Linden), "The
+  Long Memory" (Gretta's Threshling ↔ Corvin).
+- `docs/design/oakhaven_outpost/oakhaven_outpost-done.md` — Galen's Vigil (source of the handoff line),
+  `a_guildsmans_first_steps` / `head_to_whisperwood`.

--- a/docs/design/whisperwood_grove/whisperwood_grove.md
+++ b/docs/design/whisperwood_grove/whisperwood_grove.md
@@ -249,7 +249,7 @@ added later without needing to retcon anything here.
 
 **Connection to Oakhaven Outpost (Town 1):** Oakhaven already planted hints of this without
 naming it — Galen's unspoken suspicion that the Rotting Pits and the Weeping Chasm "share a
-Gloom source — same breach, different surface points" (`docs/design/done/oakhaven_outpost.md`)
+Gloom source — same breach, different surface points" (`docs/design/oakhaven_outpost/oakhaven_outpost-done.md`)
 is the same underlying phenomenon, just not yet given a framework. Whisperwood Grove —
 specifically the Weeping Root — is where the player first gets the *vocabulary* (State / Type
 / Mark) to understand what Oakhaven was hinting at. Nothing in Oakhaven needs to change; this

--- a/docs/design/whisperwood_grove/whisperwoods_plea_quest.md
+++ b/docs/design/whisperwood_grove/whisperwoods_plea_quest.md
@@ -1,0 +1,410 @@
+# whisperwoods_plea — Quest Line (Story Pass)
+
+**Status:** LOCKED (brainstorm session, no code changes yet)
+
+This doc picks up the `whisperwoods_plea` quest design, split out from the (now parked)
+`whisperwood_grove.md`. It assumes everything locked in that doc — the Lore Lock (Sylven
+Heartwood = the Heart of Decay), the Gloom Sickness State/Type/Mark framework, the Weeping
+Root remnant (Elowen, Corvin, Anora, Hollowthorn), and the new
+`aethelgard_classification.md` (Classification Tier vs. Encounter Rarity).
+
+Approach: **story first, mechanics/wiring later.** This doc is the story spine. Quest
+flags, triggers, and step-by-step implementation get their own pass once the spine is solid.
+
+---
+
+## What Exists in Code Today
+
+From Vexia's dialogue (`data/towns.py`):
+- `quest_whisperwoods_plea_active`: "The Thicket grows darker by the day. Find the source
+  of the corruption — the Heart of Decay. The forest is counting on you."
+- `quest_whisperwoods_plea_complete`: "You've shown kindness and understanding. Now, let us
+  see the strength of your bond. Face my companion — and prove yourself worthy."
+- `crest_earned`: "The Verdant Crest rests with a worthy guardian."
+
+Implied shape: find the Heart of Decay → return to Vexia → crest battle vs. Ferngale →
+earn the Verdant Crest.
+
+---
+
+## Lore Update — Unified Origin (supersedes "wound that couldn't be burned out" framing)
+
+This refines the Weeping Root's Lore Spine from `whisperwood_grove.md`, connecting it
+directly to the Ashen Verge's lore spine (also in that doc):
+
+**One organism, two surface points, no one to blame.** Generations ago, the same organism
+first broke the surface at what is now the Ashen Verge. Pyrehart fought it back — at great
+cost, leaving Pyrehart permanently wounded and dormant — and fire sealed off the part that
+had breached the surface, becoming Cindermaw: a severed, contained fragment, a scar on the
+land. But fire only ever reached the *surface*. The rest of the organism survived
+underground, untouched, and over generations its root system kept growing — slowly,
+unnoticed — until it reached and grew directly into **Sylven's own root system**. The
+Weeping Root is where that growth ended up. You can't burn it out without burning Sylven
+himself.
+
+Nobody caused this — everyone in this story has only ever *responded* to something already
+in motion: Pyrehart fought it, Kaelen's ancestors maintain the old containment ring out of
+inherited duty, Corvin found the deep growth decades ago, Anora went looking for its source
+and didn't come back, Elowen researches it now. Whether this organism is itself connected to
+the single Gloom breach site ("the Chasm," per the Mirefields/Chasm lore and Oakhaven's
+hints) is a much bigger question — deliberately left open for a later arc.
+
+**Elder pairs.** Per `aethelgard_classification.md`, Pyrehart/Cindermaw and
+Verdanthorn/Hollowthorn read as the same *kind* of phenomenon at two different sites and ages:
+an Elder that embodies a territory's vitality, paired with an Elder that embodies the same
+organism's wound at that site. Pyrehart/Cindermaw are the old, wounded, mostly-dormant pair;
+Verdanthorn/Hollowthorn are the current, active pair. Worth a brief cross-reference note in
+`aethelgard_classification.md`'s Elder tier entry.
+
+**Sylven's role, reframed.** Sylven (Ancient tier) has been fighting this from the inside the
+entire time — slowly, the way something enormous and old fights something it doesn't fully
+understand. That's *why* the corruption spreads slowly instead of overrunning everything.
+But Sylven can't finish the job: **Hollowthorn actively guards/feeds the core (Anora)**, and
+as long as that anchor point is protected, Sylven's stabilization can't take hold there.
+Removing Hollowthorn — by either branch of Beat 5 — doesn't fix anything by itself, but it
+removes the thing that was *stopping* Sylven from eventually stabilizing on its own. That
+becomes the long-term/future-arc payoff: Sylven can heal, slowly, once the active guard is
+gone. Neither branch is "the cure" — both just let Sylven try.
+
+---
+
+## Story Spine (Beats)
+
+### Beat 1 — The Quest Starts (Vexia)
+
+Existing dialogue, unchanged. Vexia sends the player to find "the Heart of Decay" in the
+Whispering Thicket / Whisperwood Wilds. At this point, the player has no reason to think
+the Heart of Decay is Sylven itself — it reads as "find the source of a corruption problem
+in the forest."
+
+### Beat 2 — Signs Point Inward, Not Outward
+
+While exploring the Thicket/Wilds, the player runs into the Withering-Marked wildlife
+already seeded in the encounter tables/explore events (Mossling, Serpentine, Glamorose).
+Per `aethelgard_classification.md`, these are **Ordinary-tier creatures with an
+Uncommon/Rare sighting** — i.e., normal animals that look *wrong*. This is the player's
+first contact with Gloom Sickness, framed as "the wildlife is getting sick," before any
+named NPC explains what's actually happening.
+
+Optional: a line or two from Arboreal or Linden registering quiet concern, without naming
+the cause — they've noticed the same thing, but don't have the vocabulary yet (that comes
+later, in the Weeping Root).
+
+### Beat 2.5 — A Small Mercy (or Not)
+
+A quiet, flavor-only Choice Event during exploration: the player finds a single
+Withering-Marked creature in clear distress — not a fight, a moment. The "options" don't
+have a clearly correct answer (help it / leave it alone / not sure helping even means
+anything here) and carry no mechanical consequence. This is the player's first time sitting
+with "I don't know what's right here" — a quiet rehearsal for Beat 5's Sever/Defeat choice.
+Could reuse/extend one of the existing Pet Sighting explore events already written for the
+Thicket/Wilds. Exact creature/wording: TBD.
+
+### Beat 3 — Fae Whisper Opens the Path
+
+Quest-only Choice Event in the Whispering Thicket. Fae Whisper steps out from between two
+roots that "weren't there a moment ago" — *"I've been down there. I don't go anymore. But
+you need to."* She opens the path down into **The Weeping Root**.
+
+This is the pivot: the "source" isn't out in the wilds, it's *underneath*, inside Sylven's
+own roots.
+
+### Beat 3.5 — The Descent
+
+A short transition beat following Fae Whisper down into the dark — tone shift from canopy
+to abyss. Mostly atmosphere/flavor text (can lean on the Weeping Root's existing Flavor
+explore events for tone). Room for one personal line from Fae Whisper about *why* she
+stopped coming back here — not plot-critical, but recontextualizes her later (ties into the
+Side Story Beat / Luna connection from `whisperwood_grove.md`). Exact line: TBD.
+
+### Beat 4 — The Weeping Root: Gathering Understanding
+
+The player meets **Elowen** (merchant, sees Gloom Sickness up close via her own Touched
+Mark and her research) and **Corvin** (lore — Verdanthorn's Reflection, the history of the
+wound, the first written account of "Petrified"/Calcifying). This is where the player gets
+the actual *vocabulary* — State / Type / Mark — for what they've been seeing since Beat 2.
+
+This beat is explicitly about understanding *before* confrontation. By the time the player
+reaches Anora, they should know:
+- What Gloom Sickness actually is (not just "corruption").
+- That it has degrees (Touched/Hollowing) and that those degrees aren't necessarily final.
+- That someone (Elowen) is actively trying to find a way to stop/reverse it.
+- That someone else (Corvin) saw it happen to a person before, decades ago.
+
+That's what makes Anora land as a *person*, not a monster, when the player gets there.
+
+**Also part of this beat: the unified-origin connection.** Corvin is the natural
+mouthpiece — he's old enough to remember (or to have records of) the Ashen Verge incident,
+and he's the one who found this deep growth in the first place. A line from him connecting
+"what fire sealed off up there" to "what you're standing in now" is the moment the player
+realizes Ashen Verge and the Weeping Root are the same wound. Exact dialogue: TBD, but this
+should land *before* Anora's Hollow, not after — it's part of the "understanding" the
+climax depends on.
+
+### Beat 4.5 — Before the Hollow
+
+A quiet beat after meeting Elowen and Corvin, before pressing on toward Anora's Hollow.
+Elowen, knowing where the player's headed, says something that isn't instructions — an
+acknowledgment, or a small request ("if you find anything that... isn't her anymore, don't
+tell me what it looked like"). Gives the climax emotional stakes from a third party who
+isn't Anora herself, and reinforces Elowen's research stake in what's about to happen.
+Exact dialogue: TBD.
+
+### Beat 5 — Anora's Hollow (Climax)
+
+The confrontation. Per the locked framing:
+- **Anora** is the host/core — fused into the root wall, State: Hollowing, Type: Withering.
+  She doesn't fight. She's the tragedy: a Guild scout who went looking for this decades ago
+  and didn't come back the same.
+- **Hollowthorn** — an **Elder**-tier being (per `aethelgard_classification.md`), Whisperwood's
+  "balance-break" mirror of Verdanthorn — has gravitated to Anora as the strongest
+  concentration of the wound, the way a guardian gravitates to a territory's heart.
+  **Hollowthorn is the actual fight.**
+- The player's choice — **Sever vs. Defeat** — is the mechanical expression of
+  "kindness and understanding" from `quest_whisperwoods_plea_complete`. Critically, **neither
+  option is a cure** — there isn't one yet (see Lore Update above). The fight against
+  Hollowthorn plays out the same either way; the choice is what happens *after* Hollowthorn
+  is beaten down:
+  - **Sever**: cut Hollowthorn's connection to the core without destroying the root-mass
+    Anora is fused into. This doesn't heal her — it **arrests her progression where it is**,
+    the same way Corvin's Calcifying stalled decades ago. She'd be left suspended,
+    Touched/Hollowing-frozen — still fused, still not herself, but no longer actively
+    worsening. Pays off Elowen's research question directly: the player just generated her
+    first real data point on whether the process *can* be stopped before it runs its course.
+  - **Defeat**: destroy Hollowthorn outright, taking the corrupted mass — and Anora — with
+    it. Faster, decisive, no ambiguity. Her alcove becomes an empty, scarred cavity.
+  - Both outcomes are bittersweet by design — "is being frozen mid-Hollowing better than
+    being released from it?" is left genuinely unclear. This fits "Town 2, no answers yet."
+- Either outcome removes Hollowthorn as the active guard on the core — stabilizing the
+  region (mirrors "the line is moving" thread from Ashen Verge, which should stop shrinking
+  once this resolves) and clearing the way for Sylven's own slow self-stabilization (see
+  Lore Update above). Full healing of Sylven himself remains a longer-term/future-arc thread.
+
+**Foreshadowing note:** the Deep Vein Choice Event (already sketched in `whisperwood_grove.md`)
+gives the player a glimpse of "something large" in the brightest vein before this point —
+that's Hollowthorn. Per the classification framework, an Elder being *sighted at all* in a
+quest-gated remnant is itself a signal that something is deeply wrong — Elders aren't
+casually encountered. Worth making sure that teaser reads as unsettling rather than just
+"strong wild pet ahead."
+
+### Beat 5.5 — The Quiet After
+
+A short beat immediately following the Sever/Defeat choice, before the player leaves the
+Hollow — alone with the result. Different flavor text depending on which choice was made
+(Sever: the suspended, frozen stillness of an arrested wound; Defeat: the empty, scarred
+cavity). This is where the "did I do the right thing?" ambiguity gets room to land, instead
+of being immediately overtaken by "now go fight Ferngale." Exact text: TBD.
+
+### Beat 6 — Return to Vexia, Crest Battle, Verdant Crest
+
+Existing locked dialogue (`quest_whisperwoods_plea_complete`, `crest_earned`). Crest battle
+vs. Vexia's companion Ferngale. Optional/light-touch idea: Ferngale's battle dialogue or
+demeanor could subtly reflect the player's Anora choice — not a hard branch, just flavor
+text variance. Not committed.
+
+### Beat 6.5 — Coda
+
+After the crest battle, back in the Thicket, something subtly different — e.g., the
+Withering-Marked creature from Beat 2.5 is gone, changed, or unchanged, depending on the
+Sever/Defeat outcome. A small, optional "did it matter" payoff that closes the loop opened
+in Beat 2.5 without requiring a hard branch elsewhere. Exact details: TBD.
+
+---
+
+## Branches — Side Quests & Side Stories (rough sketches)
+
+These are **not required** for `whisperwoods_plea`, but connect to it — mostly as payoffs
+that only make sense *after* the main spine resolves, or as texture that deepens it without
+gating it. Pulled from the "Side Story Beat (OPEN/TBD)" list and the Ashen Verge lore spine
+in `whisperwood_grove.md`, now reframed against the Unified Origin and Beat 5's Sever/Defeat
+outcome.
+
+### Branch 1 — "The Line is Moving" (Ashen Verge payoff)
+
+Bram & Pip have been quietly tracking the Ashen Verge boundary slowly shrinking (Pip marks
+it with stones), without Pyrehart at full strength to hold it. This is the *other* surface
+point of the same organism (per Unified Origin) — so **Beat 5's resolution should be visible
+here too**.
+
+- **Before (seed):** an early, pre-quest visit to Ashen Verge where Pip mentions the stones
+  casually — no weight yet, just color (this may already exist as part of the Ashen Verge
+  side-story sketch in `whisperwood_grove.md` — confirm/reuse rather than duplicate).
+- **During:** during Beat 3.5 (The Descent) or 4.5 (Before the Hollow), a small, optional
+  line where the player notices something down here that *echoes* what Pip described up
+  top — the player connects the two locations before Pip does. Flavor-only.
+- **After (payoff, two-step):** first return visit post-Beat 5 — Pip notices something's
+  different but isn't sure yet ("the stone... I don't think I need to move it today"). A
+  later visit confirms it — he's sure now, the line has held.
+- **Open question:** does Sever vs. Defeat produce any *visible* difference at Ashen Verge,
+  or is "the line stopped" identical either way? Leaning toward **identical** — the
+  stabilization is about Hollowthorn no longer guarding the shared root system, which is
+  the same regardless of Anora's specific outcome. Keeps this branch simple and avoids
+  needing two versions of Ashen Verge content.
+
+### Branch 2 — Elowen's Research / "Letting Go"
+
+Already seeded in `whisperwood_grove.md`: Elowen's Glamorose (Touched/Withering) is her
+"control subject," and there's a flagged future side-story about her eventually having to
+let it go. Beat 5's **Sever** outcome (if chosen) hands her real data for the first time —
+this branch is what she *does* with that. Naturally suited to stretching since it's already
+multi-visit by design.
+
+- **Stage 1 (first visit, pre-existing):** establishes Elowen, her Touched Mark, her
+  Glamorose, and the research framing — already covered in her NPC writeup.
+- **Stage 2 (Beat 4.5, "Before the Hollow"):** her quiet request not to be told *what it
+  looked like* — already written into Beat 4.5.
+- **Stage 3 (immediately post-Beat 5):** her reaction to what the player tells her — about
+  *meaning*, not description, per Stage 2's framing.
+  - **If Sever:** she has real data for the first time. Reaction should feel like a
+    held-breath moment — not relief exactly, more "this is the first time the question
+    isn't purely theoretical."
+  - **If Defeat:** no new data, but not "nothing" — grief without data is still something.
+    Her reaction here should carry its own weight (TBD tone), not read as the empty branch.
+- **Stage 4 (settling visits, plural):** over a few subsequent visits, her stance on her own
+  Glamorose shifts gradually rather than all at once — small dialogue variations per visit
+  rather than one big change. Direction (more hopeful vs. more resigned): TBD, depends on
+  overall tone for her arc.
+- **Stage 5 (eventual "letting go" beat):** still flagged for a future pass, possibly beyond
+  Town 2's scope entirely (could be a Town 3+ thread if Elowen remains recurring).
+
+### Branch 3 — Luna/Mira & Fae Whisper (Moonpetal Inn thread)
+
+The day/night Moonpetal Inn split (Mira/Luna) and Fae Whisper's history both involve "things
+that happen at night that don't get repeated to day-people." Naturally suited to stretching
+since it requires multiple visits/timing already.
+
+- **Before (seed):** an early, pre-quest visit to Luna (night) where she has one odd,
+  unexplained line — something that only makes sense later. No context given at the time.
+- **During (Beat 3.5):** Fae Whisper's personal line (already part of Beat 3.5) is the
+  other half of what Luna said — neither repeats what the other said (mirrors the Bram/Pip
+  "Match"/"Wisp" naming bit — a recurring texture pattern of "two people who know the same
+  thing and don't compare notes").
+- **After (payoff):** a later visit to Luna, post-Beat 3.5 — if the player brings up Fae
+  Whisper (or just based on quest progress), Luna reacts subtly, confirming the connection
+  without spelling it out. Attentive players connect the dots themselves.
+- **Payoff framing:** mostly characterization/world-texture — confirms Fae Whisper isn't
+  just "quest NPC who opens a door," she has a life/history in the town that predates the
+  quest. No mechanical reward needed; this is "the world feels lived-in" texture.
+
+### Branch 4 — Arboreal & Sylven
+
+Arboreal's healing draws from Sylven's roots (Lore Lock). Question flagged in
+`whisperwood_grove.md`: does he *know* what's happening to Sylven?
+
+- **Before (seed):** early in the quest (around Beat 2, alongside the optional
+  Arboreal/Linden "quiet concern" lines), Arboreal has a small unprompted line about the
+  roots feeling "off" — *"the roots have felt... tired, lately. I didn't know what to make
+  of it."* Plants the seed long before the player has the vocabulary to understand why.
+- **During:** no additional touchpoint needed — Arboreal doesn't have State/Type/Mark
+  vocabulary (per Beat 4), so he stays quiet through the middle beats. His not-knowing is
+  itself part of the texture.
+- **After (payoff, tied to Beat 5):** post-quest, Arboreal has a small reaction — something
+  changed in how the roots feel, even if he still can't explain it. Quiet confirmation that
+  Sylven's slow self-stabilization (per the Lore Update) has begun, told through the NPC
+  most directly connected to Sylven day-to-day, without Sylven ever appearing directly. The
+  "before" seed makes this read as *recognition* ("it's different now") rather than a new
+  reveal.
+- **Open question:** should this reaction differ between Sever/Defeat? Leaning **no**,
+  same reasoning as Branch 1 — keeps it simple, and the "did it matter" question is already
+  being asked more pointedly in Beat 6.5.
+
+---
+
+## NPC Personal Side Stories (rough sketches)
+
+Background-story content for individual NPCs, separate from the main spine and Branches
+1-4 — but several connect to each other and to the main quest. Two unlock patterns are
+used, matched to what kind of reveal it is:
+- **Quest-flag-based** — only makes sense after specific story knowledge exists.
+- **Affinity-based** — unlocked by repeated conversations/visits, independent of quest state.
+
+### The Guild Scout Thread (Vexia, Linden, Fae Whisper, Anora) — major connected web
+
+This is the big one — four NPCs' personal stories interlock around a single thread: what
+actually happened to Anora, decades ago.
+
+- **Vexia** *(quest-flag, post-Beat 5)*: Vexia knew Anora — personally, or at least knew of
+  her disappearance and was involved in the decision to stop searching. Post-Beat 5,
+  returning to Vexia for Beat 6 carries a second layer: "Face my companion, prove yourself
+  worthy" now lands differently, knowing Vexia already suspected, on some level, what was
+  down there. Possible "before" seed: an odd, unexplained reaction from Vexia to something
+  forest-related, pre-quest — recontextualized later.
+- **Linden** *(quest-flag, post-Beat 5, OR affinity — whichever reads better)*: Linden is
+  the Guild's records-keeper. This is the mechanism for the "cross-reference old Guild
+  records" gut-punch flagged back when Anora was first established. Post-quest, the player
+  can ask Linden about old expeditions — he digs up Anora's record. This is the payoff of
+  that early hook, and it's the piece that makes the thread *concrete* (a name, a date, a
+  case file) rather than just implied.
+- **Fae Whisper** *(quest-flag, tied to Beat 3.5/her personal line)*: reframe her "why I
+  stopped going back" line (Beat 3.5) — she didn't just *hear about* the wound, she's the
+  one who, on her solo trip, actually found Anora already fused into the root wall. That's
+  what she saw. That's why she doesn't go back, and why she sends the player instead of
+  going herself. This single reframe makes Beat 3.5 retroactively much heavier on a second
+  playthrough/reflection, without changing a word of what's said *at the time*.
+- **Anora**: doesn't get her own repeat-visit content — her "personal side story" *is* this
+  thread, told through the other three. (If Sever was chosen, there may be room for very
+  minimal, non-verbal acknowledgment from her in a future pass — not committed.)
+
+**Suggested unlock order:** Beat 5 resolves → Fae Whisper reframe becomes available
+(she's already met) → Vexia reveal at Beat 6 → Linden's records become askable afterward,
+as the "proof"/concrete capstone. All four pieces should be discoverable without a strict
+forced order beyond "after Beat 5," but this is the natural reading order.
+
+### Town Core (remaining NPCs)
+
+- **Arboreal** *(affinity-based)*: deepen Branch 4 — how did he come to tend the Lodge?
+  Possible angle: he was healed by Sylven himself once, long ago, and has devoted himself
+  to the Lodge ever since. Affinity-based reveal, independent of quest state; Branch 4's
+  post-Beat-5 "roots feel different" reaction stays quest-flag-based as already designed.
+- **Mira / Luna** *(affinity-based)*: why twins run day/night shifts — light personal
+  history, could carry a faint Gloom-adjacent thread (without being heavy) that
+  complements Branch 3's Luna/Fae Whisper connection rather than duplicating it.
+- **Slithers** *(affinity-based, light)*: the shop's stock includes salvage — connects
+  loosely to Bram & Pip's "stripping old ruins" economy (Ashen Verge). Mostly flavor;
+  gives Slithers *some* personality beyond "shop," and gives Bram & Pip's scavenging a
+  destination/purpose in the wider economy.
+
+### Ashen Verge
+
+- **Kaelen** *(side-quest-flag, "What's Beneath the Ash")*: once the side quest reveals
+  what the containment ritual was actually *for*, Kaelen has personal doubt — he's spent
+  his life tending something he now understands for the first time, and isn't sure how he
+  feels about that. Direct 1:1 payoff of the side quest.
+- **Bram & Pip** *(affinity-based)*: lighter personal history — why they live out here.
+  Connects to Slithers above (where their salvage ends up). Complements existing "the
+  choosing" and "the line is moving" side stories without replacing them.
+
+### Weeping Root
+
+- **Elowen**: covered by Branch 2 (Research / "Letting Go") — no separate entry needed.
+- **Corvin** *(affinity-based)*: why has he *stayed* near the wound for decades, fully
+  mobile and able to leave? His own reason — guilt, duty, an inability to look away —
+  separate from his lore-dump role. Unlocks gradually over repeated conversations, giving
+  players a reason to revisit him after the main quest ends.
+- **Anora**: see Guild Scout Thread above — no separate repeat-visit content.
+
+---
+
+## Open Questions (carried forward)
+
+1. ~~Should the player be able to attempt/complete `whisperwoods_plea` without ever finding
+   the Weeping Root?~~ — **RESOLVED: hard requirement.** It's the main story for a reason —
+   it follows through. No skipping the Weeping Root.
+2. ~~Do Beats 2-4 need their own smaller choices?~~ — **RESOLVED:** yes, but flavor-only,
+   no mechanical branching. Added as Beats 2.5 (A Small Mercy), 3.5 (The Descent), and 4.5
+   (Before the Hollow) — each rehearses or sets up the emotional weight of Beat 5 without
+   forking the quest state. Beat 5.5 (The Quiet After) and 6.5 (Coda) round out the back
+   half with the same approach.
+3. Beat 6 Ferngale flavor-variance based on Anora's outcome — yes/no, low priority. Still
+   open, not blocking.
+4. Step-by-step quest flag/trigger wiring — separate pass, after this spine is approved.
+   Now includes wiring for Beats 2.5/3.5/4.5/5.5/6.5 in addition to the original six.
+
+---
+
+## Cross-References
+
+- `whisperwood_grove.md` — town core, NPCs, Gloom Sickness framework, Weeping Root remnant
+  (Elowen/Corvin/Anora/Hollowthorn full write-ups).
+- `aethelgard_classification.md` — Classification Tier (Elder/Ancient/etc.) and Encounter
+  Rarity framework referenced throughout this doc.

--- a/docs/design/world/aethelgard_classification.md
+++ b/docs/design/world/aethelgard_classification.md
@@ -1,0 +1,86 @@
+# Aethelgard — Creature Classification & Encounter Rarity
+
+**Status:** LOCKED (brainstorm session, no code changes yet)
+
+This is a world-level framework, not specific to any one town/remnant. It was born out of
+the Whisperwood Grove design pass (see `whisperwood_grove.md`), specifically while figuring
+out where Sylven Heartwood, Verdanthorn, and Hollowthorn sit relative to each other — but it's
+meant to apply everywhere in Aethelgard, going forward.
+
+It introduces **two separate axes** that were previously conflated into one "rarity" stat:
+
+1. **Classification Tier** — what a creature fundamentally *is* (its place in the world's
+   power/significance hierarchy).
+2. **Encounter Rarity** — how often a creature is actually *seen/caught*, independent of its
+   classification.
+
+A creature's classification tier is mostly fixed (a species is what it is). Its encounter
+rarity can vary by context, region, or individual — and that variance is itself a storytelling
+tool.
+
+---
+
+## 1. Classification Tier
+
+Ordinary → Prime → Apex → **Elder** → **Ancient** → Primordial → Eternal
+
+| Tier | What it represents | Example(s) |
+|---|---|---|
+| Ordinary | Everyday wildlife. The baseline of the world. | Mossling, Sunmoth, most starter-line species |
+| Prime | A step above ordinary — more capable, still common enough to encounter regularly. | Mid-evolution-line species |
+| Apex | The "top of the food chain" for a given habitat — strong, but still part of the normal ecosystem. | Late-evolution-line species, strong standalones |
+| **Elder** | A creature that *embodies* a quality of its territory — not just strong, but a living expression of something about the place. Neutral term: an Elder can embody growth, decay, memory, etc. — good or ill is not implied by the tier itself. | Verdanthorn (Whisperwood's living guardian presence), Hollowthorn (Whisperwood's corrupted mirror/"balance-break" entity) |
+| **Ancient** | A being a territory is *built around* — foundational to that region's identity, history, and balance. Effectively one-per-major-territory. | Sylven Heartwood (Whisperwood) |
+| Primordial | Reserved / unused so far. A being whose significance extends beyond a single territory — possibly tied to Aethelgard-wide forces (the Gloom's origin point, etc.). No confirmed example yet. | — |
+| Eternal | Reserved / unused so far. The theoretical ceiling — something that predates or transcends current territorial structures entirely. No confirmed example yet. | — |
+
+**Notes:**
+- Elder tier is explicitly **dual-natured by design** — Verdanthorn and Hollowthorn are both
+  Elders of Whisperwood, one expressing the territory's health and the other its wound. Future
+  territories may or may not have both halves of an Elder pair; that's a per-region story
+  choice, not a rule.
+- **Observed Elder pairs:** Whisperwood actually has *two* such pairs, at different sites and
+  ages of the same underlying wound (see `whisperwoods_plea_quest.md` "Lore Update — Unified
+  Origin"): **Pyrehart/Cindermaw** (Ashen Verge — old, wounded, mostly dormant) and
+  **Verdanthorn/Hollowthorn** (Weeping Root — current, active). Same kind of phenomenon,
+  different stages — a useful template for how Elder pairs can recur across a single
+  territory's history, not just once per territory.
+- Primordial/Eternal are intentionally left open. Given Oakhaven Outpost's hints that the
+  Rotting Pits and Weeping Chasm "share a Gloom source — same breach, different surface
+  points," the Chasm itself (or whatever lives at its source) is a strong candidate for a
+  future Primordial/Eternal-tier entity — but this is *not* committed to anything yet.
+
+---
+
+## 2. Encounter Rarity
+
+Common → Uncommon → Rare → (further tiers TBD as needed)
+
+This is the **familiar rarity language**, but it now describes *sighting frequency*, not
+power level. It's the term Guilds, NPCs, and players would actually use day-to-day —
+"there's a rare sighting of an ordinary pet out near the Thicket" is a complete, useful
+sentence that doesn't require the listener to know anything about Classification Tiers.
+
+**Why this split matters:**
+- A creature's Classification Tier rarely changes. Its Encounter Rarity can shift based on
+  context — and *that shift is itself information* the world can react to.
+- Concrete example (already built, retroactively explained by this framework): a
+  Withering-Marked Mossling is still **Ordinary** tier — it's a Mossling. But seeing one in
+  that state is a **Rare** sighting, and an attentive Guild member would flag it as such.
+  The Mark changed how often it's *seen looking like that*, not what it fundamentally *is*.
+- This also explains things like Stillroot being listed as a "Rare" encounter in the Weeping
+  Root despite being a relatively Ordinary/Apex-level creature conceptually — the Calcifying
+  Mark is what makes it a rare sighting, not its baseline classification.
+
+---
+
+## Open / Future Work
+
+- No code changes yet — this is conceptual scaffolding for future design passes.
+- Primordial/Eternal tiers remain unassigned. Don't force an example into existence just to
+  fill the table.
+- Future town/remnant docs should reference this file rather than re-deriving rarity
+  language locally.
+- Possible future pass: formalize how Encounter Rarity interacts with capture mechanics
+  (does a "Rare sighting" of an Ordinary pet have different catch-rate odds than a baseline
+  Ordinary encounter? Not decided.)

--- a/docs/design/world/aethelgard_gloom_frames.md
+++ b/docs/design/world/aethelgard_gloom_frames.md
@@ -1,0 +1,148 @@
+# Aethelgard — Gloom Frames (Philosophy Pass, Work in Progress)
+
+**Status:** WIP brainstorm — builds on the (separately locked) Seven Gloom States and their
+parallel to Classification Tier. This doc is specifically about the **Philosophy
+section** of that framework: Frames/Paths/Factions — different in-world beliefs about what
+the Gloom *means* — and how they already show up (or conspicuously don't) across the
+quests and lore we've built so far.
+
+**Core idea (from the source philosophy):** the Gloom is not inherently good or evil. It's
+a fundamental force. Different people construct different narratives around it — the Guild
+studies it, hunters fear it, healers mourn it, some seek to become it, some believe the
+Unbound are finally free, some believe Oblivion is the world's oldest truth. No frame is
+"correct." They're lenses on the same mystery.
+
+---
+
+## Part 1 — Frames We've Met
+
+These aren't new inventions — they're names for stances our existing NPCs *already* hold,
+unlabeled. Naming them retroactively is a sanity check: if the philosophy is right, it
+should describe what we've already written without forcing anything.
+
+| Frame | Stance | Who embodies it | Where it shows up |
+|---|---|---|---|
+| **The Scholar's Frame** | Study it, catalog it, withhold judgment until there's data — even if the data never comes. | Kael (Weeping Chasm), Linden (Whisperwood) | "The Threnody Correspondence" — a question asked and never answered, by two people who never compared notes. The frame's limitation *is* the story. |
+| **The Hunter's/Subduer's Frame** | Don't moralize. Establish dominance. Don't name what you've subdued. | "Grim" Gretta (Weeping Chasm) | Her Threshling. "I didn't purify it. I made it clear who was in charge." No theory offered, none wanted. |
+| **The Healer's/Mourner's Frame** | Grief first, understanding maybe later, acceptance eventually. | Elowen (Weeping Root) | Branch 2 ("Letting Go") — her staged arc (held-breath data → grief without data → gradual shift → eventual letting go) is essentially this frame's *emotional arc made literal*. |
+| **The Watcher's Frame** | Distrust institutions. Quiet vigilance over paperwork. | Grit Galen (Oakhaven) | Galen's Vigil — "the Guild responds to paperwork, not to slow disasters." Doesn't believe documentation helps, unlike the Scholar's Frame. |
+| **Lived Experience (unsorted)** | No frame at all — just decades of proximity and acceptance. | Corvin (Weeping Root) | "The Long Memory" — recognizes Gretta's Threshling without needing a theory about it. Possibly the most quietly radical position in the cast: *you don't need a frame to live with this.* |
+
+---
+
+## Part 2 — Frames We Haven't Met Yet
+
+The philosophy explicitly names three stances that **nothing in our current cast holds**:
+
+- **"Some seek to become it."** — A frame that *wants* a Gloom relationship. Not present
+  anywhere. Even Hollowthorn/Cindermaw (Wrought) aren't willing participants — they're
+  outcomes, not believers.
+- **"Some believe the Unbound are finally free."** — The flip side of Forsaken's "some
+  envy them." Nobody we've written voices this.
+- **"Some believe Oblivion is the world's oldest truth."** — A fatalist/quasi-religious
+  frame, scaled to Primordial/Eternal. Nothing close exists yet.
+
+This gap reads as **correct, not incomplete** — three remnants in, every frame we've
+written is some flavor of "respond carefully." That itself says something: every NPC the
+player has met so far is Guild-adjacent or otherwise embedded in a *response* structure.
+Nobody the player has met has had the luxury (or the inclination) to *want* anything from
+the Gloom.
+
+---
+
+## Part 3 — Brainstorm: Additional Frame Candidates & NPC Seeds
+
+### Frames hiding in plain sight (retroactive, like Part 1)
+
+- **The Pragmatist's Frame / Non-Engagement** — "Not everything's meant to last." This
+  isn't a *Gloom* frame exactly (Mirefields is explicitly non-Gloom), but it's the same
+  *shape* of question — investigate vs. leave alone — applied to something else. **Sable**
+  already embodies this, and her tension with **Ferryn** (Scholar's Frame, Mirefields
+  flavor) is a smaller, lower-stakes echo of the Kael/Linden dynamic. Worth naming as a
+  frame in its own right: *some people don't need a relationship with the unknown at all,
+  and that's not ignorance — it's a choice.*
+- **The Guardian's/Protector's Frame** — Distinct from the Hunter's Frame: the Hunter
+  dominates *a thing*; the Guardian defends *a place* (or people) *from* a thing, without
+  needing to understand or subdue it personally. **Verdanthorn** embodies this on the
+  creature side — the "health" half of an Elder pair, standing against Hollowthorn. We
+  don't yet have a *human* NPC who holds this frame explicitly — a candidate for a future
+  remnant.
+
+### Genuinely new candidates
+
+- **The Skeptic's/Rationalist's Frame** — "There's no 'Gloom.' There's decay, disease,
+  and people who'd rather have a name for it than a cure." A frame that pushes back on the
+  entire vocabulary — Touched/Shorn/Hollow/etc. as mythologizing rather than describing.
+  **NPC seed:** a second scholar, somewhere down the line, whose disagreement with Kael (or
+  someone like him) isn't personal — it's epistemological. Two Scholar's-Frame-adjacent
+  people who can't agree on what they're even studying. Good friction for a future
+  Weeping-Chasm-adjacent or Town 3 location.
+- **The Devotional/Believer's Frame** — Reverence rather than fear or grief. A Wrought
+  being isn't a wound to that frame — it's sacred, a territory's truest expression of
+  itself. **NPC/settlement seed:** a small, isolated community (future remnant) built
+  around — or in the shadow of — a Wrought entity, who have built ritual/tradition around
+  it rather than fleeing or fighting. Could be unsettling specifically *because* they seem
+  happy and functional.
+- **The Opportunist's Frame** — No belief system at all — Gloom-touched materials/creatures
+  are just inventory. **Existing seed, expandable:** Bram & Pip's salvage trade and
+  Slithers' shop already gesture at this economically. A future pass could introduce a
+  black-market angle — someone actively *seeking out* Gloom-adjacent materials for profit,
+  with zero interest in what any of it means. Friction with the Guild's Scholar's Frame
+  (which would want those materials studied, not sold) is built-in.
+- **The Seeker's Frame (first real attempt at the missing "want to become it" stance)** —
+  **NPC seed:** rather than a cult or villain (too on-the-nose this early), maybe a
+  *traveler* — someone the player meets briefly, who asks unusually specific questions
+  about Wrought/Unbound beings, with an interest that reads as admiration rather than fear
+  or study. Doesn't act on it. Just... present, once, somewhere unexpected. Plant without
+  explaining — same discipline as everything else so far.
+
+---
+
+## Part 4 — How Frames Could Surface in Future Design
+
+- **Frame-vs-frame tension within a single location is a reusable template.** Sable vs.
+  Ferryn (Pragmatist vs. Scholar, low-stakes, non-Gloom) is structurally the same shape as
+  Kael vs. [a future Skeptic] (Scholar vs. Rationalist, higher-stakes). The *shape* of "two
+  people who care about the same place for incompatible reasons, neither one wrong" is
+  worth reusing deliberately.
+- **Avoid a morality-meter trap.** Frames shouldn't become a "pick a faction, get a
+  reputation track" system — that would flatten exactly the ambiguity the philosophy is
+  built on. Better: the player can *recognize* frames (per the cross-remnant connections
+  work — "I've seen this shape before"), occasionally have a dialogue choice that *briefly*
+  aligns with one frame's logic, but nothing should lock the player into a frame
+  permanently. The player is the one character who gets to hold *all* the frames at once,
+  which is itself part of what makes the connections doc work.
+- **New frames are probably better seeded in *new* remnants than retrofitted into
+  existing ones.** We've found good retroactive matches for Parts 1 and the "hiding in
+  plain sight" half of Part 3 — but the genuinely new frames (Skeptic, Devotional,
+  Seeker, Opportunist-as-black-market) likely belong to places/NPCs we haven't built yet,
+  rather than bolted onto Whisperwood/Weeping Chasm/Mirefields after the fact.
+
+---
+
+## Open Questions
+
+1. Should "Frames We've Met" be referenced explicitly in-world (NPCs naming their own
+   stance), or should it stay purely a design-side organizing tool, with NPCs continuing
+   to just... be themselves? Leaning: **the latter** — none of Part 1's NPCs currently use
+   this language, and forcing it in might flatten their voices.
+2. Is there a natural "first" candidate among the new frames (Skeptic, Devotional, Seeker,
+   Opportunist) for whichever remnant gets built next, or should this stay a loose pool to
+   draw from as needed?
+3. Should the Seeker's Frame's "traveler" NPC seed be planted *now* (in an existing
+   remnant, as a one-off appearance) or held entirely for later? Planting early would mean
+   a long-delayed payoff, similar to the "mid-sentence records" motif.
+
+---
+
+## Cross-References
+
+- `aethelgard_classification.md` — Classification Tier framework (Seven Gloom States
+  parallel lives here per your existing work).
+- `whisperwoods_plea_quest.md` — Branch 2 ("Letting Go") as the Healer's/Mourner's Frame's
+  fullest expression so far.
+- `echoes_from_below_quest.md` — Scholar's Frame (Kael), "The Threnody Correspondence,"
+  "The Long Memory."
+- `mirefields_main_quest.md` — Pragmatist's Frame (Sable) vs. Scholar's Frame (Ferryn) as
+  a low-stakes template for frame-vs-frame tension.
+- `docs/design/oakhaven_outpost/oakhaven_outpost-done.md` — Watcher's Frame (Galen's Vigil).

--- a/docs/design/world/aethelgard_world_connections.md
+++ b/docs/design/world/aethelgard_world_connections.md
@@ -1,0 +1,241 @@
+# Aethelgard — Cross-Remnant World Connections
+
+**Status:** LOCKED (brainstorm session, no code changes yet)
+
+This is a world-level connective-tissue doc, sitting alongside `aethelgard_classification.md`.
+Where `whisperwoods_plea_quest.md`'s "NPC Personal Side Stories" section connects NPCs
+*within* Whisperwood Grove (the Guild Scout Thread, etc.), this doc does the same thing one
+level up — connecting **remnants to each other** through shared lore, records, and people who
+plausibly crossed paths.
+
+**Important framing:** none of this requires a full main-story pass on Weeping Chasm or
+Mirefields to exist. These are seeds — lore threads and "connection quest" sketches that can
+sit dormant in their home docs until those remnants get their own story passes. When that
+happens, this doc is the checklist of things worth preserving/paying off. In the meantime,
+a couple of these threads can be picked up *from the Whisperwood side* (as capstones to the
+Guild Scout Thread, etc.) without touching Weeping Chasm or Mirefields content at all.
+
+---
+
+## 1. The "Mid-Sentence" Motif
+
+Three records, three remnants, same shape — found independently, not by design, but too
+good to not use:
+
+- **Weeping Chasm** — Kael's Veilmother research note: *"One entry. No follow-up. The next
+  page is blank."*
+- **Weeping Chasm** — Kael's Chasmbane note: *"stops mid-sentence."*
+- **Mirefields** — the `waystation_ledger` item: *"Last entry cuts off mid-sentence."*
+
+**The idea:** this isn't supernatural censorship, and it isn't ever explained as such. It's a
+pattern an attentive player (or an in-world scholar) could notice: **the closer a record gets
+to something true about the Gloom, the more likely it is to simply... stop.** Not destroyed,
+not redacted — just unfinished. Nobody finishes the sentence because nobody *can*, not because
+something stops them.
+
+This rhymes with the Unified Origin's core theme ("nobody caused this — everyone only
+responded"). It's another way of saying: **understanding has a ceiling right now**, and the
+world's own records reflect that honestly.
+
+**Possible future use:** a late-game or Town 3+ "connection quest" where the player physically
+collects/compares these unfinished records side by side. The payoff isn't an answer — it's the
+*recognition* that this has happened in three different places, to three different people, and
+none of them noticed because none of them could see the others. The player can. That's the
+reward: a wider view than any single NPC has.
+
+---
+
+## 2. Whisperwood ↔ Weeping Chasm — "The Threnody Correspondence"
+
+**Anchor points:**
+- Whisperwood: Linden (Guild records-keeper, already slated as the Guild Scout Thread's
+  "concrete capstone" — cross-references old Guild records for Anora's case).
+- Weeping Chasm: Lore-Keeper Kael (scholar, records-keeper, names his Duskspinner "Threnody" —
+  a funeral song, referencing the Gloom's origin in collective sorrow).
+
+**The connection:** two record-keepers in two different remnants, both quietly cataloguing
+Gloom-related anomalies, who have corresponded with each other for years — Guild scholars
+exchange notes across postings as a matter of course.
+
+**Concrete hook:** when the player reaches Linden's capstone reveal (post-Beat-5, Anora's
+case file), one of the cross-referenced documents is a years-old letter *from Kael* — a
+general inquiry asking whether any other outposts have records of "scouts or wardens who
+went missing near a Gloom-source and were later... accounted for, but changed." Linden's
+reply at the time was "no relevant cases." It's dated *before* Anora went missing. Nobody
+ever sent the follow-up.
+
+**What this does:**
+- Reframes Anora's case as not unique — just the first one anyone could actually point to.
+- Gives Kael's quiet obsession with Veilmother/Chasmbane lore a reason: he's been looking for
+  exactly this pattern for a long time, in the wrong place.
+- Doesn't require visiting Weeping Chasm to land — it can be fully delivered through Linden's
+  dialogue in Whisperwood. If/when Weeping Chasm gets a story pass, Kael can have a mirrored
+  beat: an old, unanswered letter *to* Linden, and the player can be the one who finally
+  closes that loop in person.
+
+---
+
+## 3. Weeping Root ↔ Weeping Chasm — "The Long Memory" (Corvin)
+
+**Anchor points:**
+- Weeping Root: Corvin — Calcifying-type Gloom sickness, "exposure predates the Withering
+  Type... pre-Guild, long ago." Slated for an affinity-based personal story: why has he
+  stayed near the wound for decades despite being mobile?
+- Weeping Chasm: Gretta's Threshling/Threshbound — the established in-world precedent for
+  Calcifying-type ("caught at the threshold... not fully Hollowed, locked in between states").
+
+**The connection:** Corvin's Calcifying exposure happened long before the Guild had a name
+for any of this — and long before Gretta caught her Threshling. The idea isn't that they know
+each other now. It's that **Corvin recognizes the shape of what Gretta has**, because he's
+seen it before, somewhere else, a long time ago — possibly near the Chasm itself, in his
+youth, before it was called that.
+
+**Concrete hook:** Corvin's affinity dialogue (deepening over repeated visits) eventually
+touches on this — not as a confession, but almost offhand: *"There's a creature out east, past
+the Mire, held at a threshold by someone with more nerve than sense. I've never seen it. I
+don't need to. I know what that looks like."* He doesn't explain how he knows. The player who's
+been to Weeping Chasm and met Gretta will recognize it immediately. The player who hasn't
+gets a hook for later.
+
+**What this does:**
+- Gives Corvin's decades of staying near the wound a *reason that predates the wound* — he
+  already understood, in a small way, what "stuck between states" means, before Anora, before
+  Hollowthorn.
+- Doesn't require Corvin and Gretta to ever meet. The connection is thematic/experiential,
+  carried by the player.
+- If Weeping Chasm gets a story pass later, Gretta could get a mirrored, much smaller beat —
+  someone she's never met, from a remnant she's never been to, apparently knew about her
+  Threshling before she caught it. Unsettling, not explained.
+
+---
+
+## 4. Mirefields ↔ Weeping Chasm — "Probably" (Ferryn echoes Anora)
+
+**Anchor points:**
+- Mirefields: Ferryn — seasonal researcher, Deep Mire thread, field notes left behind suggest
+  she went closer to the Mirewarden's territory than she told Sable. Fate ambiguous: "She
+  probably left. Probably."
+- Weeping Chasm: Kael's `lore_gloom_origin` — single Gloom breach theory ("the Chasm").
+
+**The connection:** Ferryn's research, on its own, is a local Mirefields mystery. But her
+field notes can be written to reference "the Chasm" as a working hypothesis — she'd heard
+Kael's collective-grief/single-breach theory (scholars talk, see Connection #2) and was
+trying to find evidence of a *second* expansion point, geographically closer to her own
+territory. The Deep Mire, in her notes, isn't just "deep and dangerous" — it's a candidate for
+exactly the kind of thing Kael theorized about.
+
+**Structural echo (the real point):** Ferryn's arc — researcher gets close to a Gloom-adjacent
+unknown, goes further than told, doesn't come back, fate left deliberately ambiguous — is the
+*same shape* as Anora's, just earlier in its timeline and with no Hollowthorn-equivalent (yet)
+to give it a resolution. The player who's completed `whisperwoods_plea` and then encounters
+Ferryn's notes should feel an uncomfortable familiarity: *I've seen this before. I know how
+this can end.*
+
+**Concrete hook:** if/when Mirefields gets its own story pass, the Deep Mire arc doesn't need
+to resolve Ferryn's fate cleanly — in fact it probably shouldn't, yet. But it could include a
+moment where the player *recognizes* the pattern from Whisperwood and says so (a dialogue
+choice/flavor line), and an NPC (Sable?) reacts — not understanding the reference, just
+noting that the player seems to already know something about this kind of disappearance.
+That's connective tissue without forcing either remnant's mystery to resolve the other's.
+
+---
+
+## 5. Whisperwood ↔ Mirefields — "What the Ledger Knew"
+
+**Anchor points:**
+- Mirefields: geographically *between* Weeping Chasm and Whisperwood Grove. The Old
+  Crossroads, `waystation_ledger` ("trader records... last entry cuts off mid-sentence").
+- Whisperwood: Anora's route. She was a Guild scout investigating something near/around the
+  Weeping Root — which, per the Unified Origin, is connected underground to Ashen Verge, and
+  per Connection #2/#4, the Chasm is part of the same wider conversation.
+
+**The connection:** if Anora (or scouts like her) traveled between outposts on Guild
+business, the most direct route between Whisperwood and anywhere east would plausibly pass
+through Mirefields' Old Crossroads — back when it was active. The ledger's final, unfinished
+entry could be **dated around the time Anora went missing** — not necessarily *about* her by
+name, but close enough in time and route that an attentive reader could connect the dots.
+
+**Concrete hook:** the ledger entry doesn't need to mention Anora. It could be as simple as a
+trader's note: *"Guild scout passed through again, headed east. Said she'd be back inside the
+month for the return trip. Didn't seem worried."* — and then nothing. The crossroads went
+quiet not long after. Whether the crossroads' decline and Anora's disappearance are *actually*
+related, or just coincide in time, is left open — same spirit as the Unified Origin's "nobody
+to blame, only responses."
+
+**What this does:**
+- Gives the already-existing `waystation_ledger` item a payoff without requiring new items.
+- Adds one more "mid-sentence" record (see #1) tied to a specific, recognizable moment for
+  players who've finished `whisperwoods_plea`.
+- Reinforces Mirefields' "place between things" framing — it's not just geographically
+  between Weeping Chasm and Whisperwood, it's *narratively* between them too: a place things
+  pass through and sometimes don't come back from, but quietly, without anyone noticing at
+  the time.
+
+---
+
+## 6. Ashen Verge ↔ Mirefields — "The Crossroads Trade"
+
+**Anchor points:**
+- Ashen Verge: Bram & Pip — live out near the ruins, make a living stripping salvage,
+  already loosely connected to Slithers' shop stock in Whisperwood.
+- Mirefields: the Old Crossroads — once an active trade waystation, now quiet.
+
+**The connection:** the most mundane of the threads, and useful for that reason — not
+everything needs to be Gloom-related. Bram & Pip's salvage trade needed *somewhere to sell*,
+and the Old Crossroads is the obvious answer: it's where traders met. When the crossroads
+went quiet (see #5), Bram & Pip's trade route got longer/harder — part of why they're "still
+out here" doing something that's clearly gotten less profitable over time.
+
+**Concrete hook:** an affinity-deepening line from Bram or Pip — *"Used to be easier, selling
+what we found. There was a crossroads, east of here, traders came through regular. Haven't
+been able to make that trip work in years."* Doesn't reference the Gloom at all on its
+surface — just quietly ties two remnants' everyday economies together, and gives the
+Old Crossroads' decline a second, independent witness (alongside the ledger itself).
+
+---
+
+## 7. Summary — Connection Quest Candidates
+
+| Working Title | Remnants | Carrier | Requires story pass on other remnant? |
+|---|---|---|---|
+| The Threnody Correspondence | Whisperwood ↔ Weeping Chasm | Linden (capstone reveal) | No — fully deliverable from Whisperwood side |
+| The Long Memory | Weeping Root ↔ Weeping Chasm | Corvin (affinity story) | No — thematic echo, no direct contact needed |
+| Probably | Mirefields ↔ Weeping Chasm | Ferryn's field notes | Mirefields side only; Chasm side optional later |
+| What the Ledger Knew | Whisperwood ↔ Mirefields | `waystation_ledger` | No — ledger text edit only |
+| The Crossroads Trade | Ashen Verge ↔ Mirefields | Bram & Pip (affinity story) | No — Ashen Verge side only |
+| The Mid-Sentence Records | All four | Late-game/Town 3+ collection thread | Eventually, for full payoff — but seeds work standalone |
+
+**Key takeaway for the open question ("does a main story for Weeping Chasm/Mirefields make
+this easier?"):** not strictly necessary — five of these six threads can be seeded *right now*
+through Whisperwood/Ashen Verge-side content alone (Linden, Corvin, Bram & Pip, the ledger
+item text). A future Weeping Chasm/Mirefields main-story pass would let these threads pay off
+*from the other direction too* (Kael, Gretta, Ferryn, Sable each get a small mirrored beat),
+turning one-way nods into proper two-way connections — but that's an enhancement, not a
+prerequisite.
+
+---
+
+## Cross-References
+
+- `whisperwoods_plea_quest.md` — Guild Scout Thread (Linden, Vexia, Fae Whisper, Anora),
+  Unified Origin lore, NPC Personal Side Stories.
+- `aethelgard_classification.md` — Classification Tier / Encounter Rarity framework;
+  Elder pairs note.
+- `whisperwood_grove.md` — town core, Ashen Verge, Weeping Root (reference only, not edited).
+- `mirefields.md` — Sable, Ferryn, Old Crossroads, Deep Mire future-arc thread.
+- `weeping_chasm_v2.md` — Orin, Kael, Gretta, Veilmother/Chasmbane, Threshling/Threshbound.
+- `docs/design/oakhaven_outpost/oakhaven_outpost-done.md` — Galen's Vigil, "shared Gloom source" hint.
+
+---
+
+## Open Questions
+
+1. Should "The Mid-Sentence Records" collection thread be Town 3+ scope, or could a lighter
+   version (just *noticing* two of the three) work earlier? Leaning: plant the seeds now
+   (ledger text, Kael's notes already exist/are planned), formalize the collection quest later.
+2. "The Threnody Correspondence" and "The Long Memory" can both be added to
+   `whisperwoods_plea_quest.md`'s NPC Personal Side Stories section (Linden and Corvin
+   entries respectively) without waiting on anything else. Worth doing in the same pass?
+3. Galen's Vigil (Oakhaven) wasn't given its own connection thread above — it's more about
+   Rotting Pits/Weeping Chasm than about Whisperwood. Worth a "Section 8" once Oakhaven's
+   place in this web is clearer, or fold into a future Weeping Chasm pass.

--- a/docs/design/world/implementation_roadmap.md
+++ b/docs/design/world/implementation_roadmap.md
@@ -1,0 +1,130 @@
+# Aethelgard — Implementation Roadmap (Design → Code Layering)
+
+Status: WIP reference. This is a suggested *order*, not a gate — design docs
+remain the source of truth, this just sequences "what to wire next" so batches
+build on top of each other instead of crossing wires.
+
+---
+
+## Layer 0 — Already Done
+
+- `oakhaven_outpost/oakhaven_outpost-done.md` — tutorial hub, fully wired.
+  `a_guildsmans_first_steps` → `head_to_whisperwood` assignment.
+
+---
+
+## Layer 1 — Per-Remnant Main Stories (geography order)
+
+Each is mostly self-contained — wires one remnant's quest line using NPCs/
+locations already described in that remnant's core doc. Suggested order
+follows the travel route (`Oakhaven → Weeping Chasm → Mirefields →
+Whisperwood`), since that's the order a new player encounters them, even
+though none of these are hard-gated.
+
+1. **Weeping Chasm — `echoes_from_below`**
+   (`weeping_chasm/echoes_from_below_quest.md` + `weeping_chasm/weeping_chasm_v2.md`)
+   - Small prerequisite touch: add Galen's one new handoff line in Oakhaven
+     (quoted in the quest doc) — doesn't change Oakhaven's `-done` quest
+     structure, just adds a dialogue line.
+   - New quest: Kael as giver/resolver, 6 beats + 4 stretch beats →
+     objectives (talk_npc/travel/item_pickup/combat per the beat list).
+   - Reward: lore-only per current draft (open question in doc).
+
+2. **Mirefields — "Readings from the Edge"**
+   (`mirefields/mirefields_main_quest.md` + `mirefields/mirefields.md`)
+   - Folds existing "Ferryn's Fetch" stub + Old Crossroads ledger Choice
+     Event into one optional `side`-type quest.
+   - Sable/Ferryn dialogue already exists in `mirefields.md` — mostly
+     quest-wrapper + a couple of new lines (Beat 4.5 conditional dialogue).
+
+3. **Whisperwood Grove — `whisperwoods_plea`**
+   (`whisperwood_grove/whisperwoods_plea_quest.md` + `whisperwood_grove/whisperwood_grove.md`)
+   - Largest of the three — bigger cast, has the one *real* hard gate
+     (`whisperwoods_plea_weeping_root_unlocked` for `weepingRoot` connection
+     in `data/towns.py`, currently unwired).
+   - Natural last in Layer 1 since it's the heaviest lift and the gate only
+     matters once this is live.
+
+---
+
+## Layer 2 — Branches / Side Quests (per remnant, optional)
+
+These ride on top of Layer 1's NPCs and locations — easiest to wire
+immediately after (or alongside) each remnant's main story while that
+remnant's context is fresh, but nothing breaks if they slip to a later pass.
+
+- **Weeping Chasm**: Branch 1 "The Sealed Journal" (Kael), Branch 2 "What
+  Spun That" (Veilmother/Orin), Branch 3 "Held at the Threshold" (Gretta),
+  Branch 4 "Orin's Posting" (affinity).
+- **Mirefields**: Branch 1 "The One Who Stayed" (Sable), Branch 2 "Probably"
+  (Ferryn, seasonal), Branch 3 "The Crossroads Trade" (one dialogue line,
+  no quest wrapper).
+- **Whisperwood**: per `whisperwoods_plea_quest.md` NPC mapping (larger set,
+  not detailed here).
+
+---
+
+## Layer 3 — Cross-Remnant Connections
+
+(`world/aethelgard_world_connections.md`)
+
+Each connection thread touches dialogue/lore in **two** remnants — wire these
+*after* both endpoints' Layer 1 (and ideally Layer 2, where the thread lives
+in a branch) are done, so the "answering" side has something to answer.
+
+Suggested order, by readiness once Layer 1/2 land in the order above:
+
+1. **"The Sealed Journal" → "The Threnody Correspondence"** (Weeping Chasm
+   Branch 1 ↔ Whisperwood's Linden capstone) — both sides depend on
+   Whisperwood being live, so this is naturally last among the three Weeping
+   Chasm/Whisperwood threads.
+2. **"The Long Memory"** (Weeping Chasm Branch 3 / Gretta ↔ Weeping Root's
+   Corvin) — same dependency (Weeping Root content).
+3. **"Probably"** (Mirefields Branch 2 / Ferryn ↔ Weeping Chasm's
+   `lore_gloom_origin`) — both sides ready once Layers 1 for Weeping Chasm
+   and Mirefields are done; doesn't need Whisperwood. Could move earlier.
+4. **"What the Ledger Knew"** (Mirefields' `waystation_ledger` ↔ Whisperwood)
+   — needs Whisperwood live.
+5. **"The Crossroads Trade"** (Ashen Verge's Bram & Pip ↔ Mirefields' Sable)
+   — both already-implemented remnants; could be done any time, low
+   priority/low effort (dialogue-only on both sides).
+6. **"The Mid-Sentence Motif"** — not a quest, just a stylistic consistency
+   note (how "the record stops" reads across Kael/Mirefields' ledger);
+   apply opportunistically while writing the above, not its own batch.
+
+---
+
+## Layer 4 — World Reference Data (flavor/lore, no urgency)
+
+- `world/aethelgard_classification.md` — already partially in
+  `data/classifications.py` as reference data (not wired into game logic).
+- `world/aethelgard_gloom_frames.md` — philosophy/frames brainstorm. Not a
+  quest-implementation target; pull from this *as* Layers 1-3 are written
+  (e.g. "does this NPC's reaction match a Frame we've defined?"), and treat
+  gaps (Seeker/Liberationist/Fatalist frames) as seeds for *future* remnants,
+  not retrofits.
+
+---
+
+## Quick-Reference Table
+
+| Layer | What | Depends on | Player-facing gate? |
+|---|---|---|---|
+| 0 | Oakhaven Outpost | — | Yes (only hard gate before Weeping Chasm) |
+| 1a | Weeping Chasm main (`echoes_from_below`) | Layer 0 (1-line dialogue add) | No |
+| 1b | Mirefields main (`Readings from the Edge`) | Layer 1a not required | No |
+| 1c | Whisperwood main (`whisperwoods_plea`) | Layer 1a/1b not required | Partial (`weepingRoot` gate) |
+| 2 | Branches/side quests per remnant | That remnant's Layer 1 | No |
+| 3 | Cross-remnant connections | Both endpoints' Layer 1 (+2 where thread lives in a branch) | No |
+| 4 | World reference docs (classification, frames) | Ongoing reference, not a build target | No |
+
+---
+
+## Cross-References
+
+- `weeping_chasm/echoes_from_below_quest.md`
+- `mirefields/mirefields_main_quest.md`
+- `whisperwood_grove/whisperwoods_plea_quest.md`
+- `world/aethelgard_world_connections.md`
+- `world/aethelgard_gloom_frames.md`
+- `world/aethelgard_classification.md`


### PR DESCRIPTION
## Summary
- Add `classification_tier` (Ordinary/Prime/Apex/Elder) to all 52 pet species/stages in `data/pets.py`, intrinsic to each species and independent of where it's encountered.
- Introduce a new 7-rung Encounter Rarity scale (Normal/Odd/Rare/Peculiar/Strange/Uncanny/Unknown) with selection weights in `data/classifications.py`.
- Restructure all 8 `ENCOUNTER_TABLES` zones into per-location `{species, encounter_rarity}` entries, replacing the old repetition-weighted flat lists. Gloom-touched residents read as "Normal" in their home territory, with "Odd"+ reserved for out-of-place sightings (a future Gloom-spread signal).
- Update `cogs/adventure.py`: weighted wild-species selection (`choose_wild_species`, with legacy-format fallback) and `classification_tier`-based shared-vs-unique passive assignment (with rarity-based fallback for safety).
- Bump Stillroot to Apex tier so its unique Stonecrust passive isn't overridden by the shared passive pool.
- Plus design-doc updates (Weeping Chasm/Mirefields story docs, world connections, Gloom frames, implementation roadmap, docs README).

## Test plan
- [ ] `python -c "from data.pets import PET_DATABASE, ENCOUNTER_TABLES"` — sanity import check
- [ ] Trigger wild encounters in a few zones (Whisperwood Grove/Wilds, Ashen Verge, Weeping Chasm, Weeping Root) and confirm pets generate correctly with passives
- [ ] Spot-check Stillroot's passive shows as Stonecrust when caught wild