### PR TITLE
Weeping Chasm: Echoes From Below quest + ambient-NPC template

### DIFF
--- a/cogs/adventure.py
+++ b/cogs/adventure.py
@@ -135,11 +135,18 @@ class Adventure(commands.Cog):
                 objectives = q_data.get('objectives', [])
                 if current_step < len(objectives):
                     obj = objectives[current_step]
-                    if (obj.get('type') == 'item_pickup'
-                            and obj.get('zone') == location_id
-                            and obj['target'] not in owned_item_ids):
-                        quest_item_to_drop = obj['target']
-                        break
+                    if obj.get('type') == 'item_pickup' and obj.get('zone') == location_id:
+                        required_count = obj.get('required_count', 1)
+                        current_count = quest['progress'].get('current_count', 0)
+                        if required_count > 1:
+                            # Stackable quest item — keep dropping until the
+                            # required count is reached, regardless of inventory.
+                            if current_count < required_count:
+                                quest_item_to_drop = obj['target']
+                                break
+                        elif obj['target'] not in owned_item_ids:
+                            quest_item_to_drop = obj['target']
+                            break
 
             if is_on_tutorial_battle_step:
                 outcome = "tutorial_pet"
@@ -160,12 +167,15 @@ class Adventure(commands.Cog):
             is_night_time = time_of_day in ('evening', 'night')
 
             if outcome == "flavor_event":
+                active_quest_ids = {q['quest_id'] for q in active_quests}
                 # Filter events by time — events with no "time" key fire any time
                 eligible_events = [
                     e for e in zone_events
-                    if 'time' not in e
-                    or (e['time'] == 'night' and is_night_time)
-                    or (e['time'] == 'day' and not is_night_time)
+                    if ('time' not in e
+                        or (e['time'] == 'night' and is_night_time)
+                        or (e['time'] == 'day' and not is_night_time))
+                    and ('required_quest_active' not in e
+                         or e['required_quest_active'] in active_quest_ids)
                 ]
                 if not eligible_events:
                     eligible_events = zone_events  # fallback — never leave the pool empty
@@ -425,6 +435,9 @@ class Adventure(commands.Cog):
                 if qty > 0:
                     await db_cog.add_item_to_inventory(user_id, item_id, qty)
                     log_list.append(f"*(+{qty}× {item_name})*")
+                    quest_updates = await check_quest_progress(self.bot, user_id, "item_pickup", {"item_id": item_id})
+                    if quest_updates:
+                        log_list.extend(quest_updates)
                 else:
                     # Negative qty = cost; silently skip if player doesn't have it
                     await db_cog.remove_item_from_inventory(user_id, item_id, abs(qty))

--- a/cogs/database.py
+++ b/cogs/database.py
@@ -142,6 +142,26 @@ class Database(commands.Cog):
             user_id, flag
         )
 
+    async def get_counter(self, user_id: int, counter_key: str) -> int:
+        """Read a generic per-player counter (e.g. a location visit count).
+        Defaults to 0 if it has never been incremented."""
+        value = await self.pool.fetchval(
+            'SELECT value FROM player_counters WHERE player_id = $1 AND counter_key = $2',
+            user_id, counter_key
+        )
+        return value or 0
+
+    async def increment_counter(self, user_id: int, counter_key: str, amount: int = 1) -> int:
+        """Increment (or create) a generic per-player counter and return its new value."""
+        return await self.pool.fetchval(
+            '''INSERT INTO player_counters (player_id, counter_key, value)
+               VALUES ($1, $2, $3)
+               ON CONFLICT (player_id, counter_key)
+               DO UPDATE SET value = player_counters.value + $3
+               RETURNING value''',
+            user_id, counter_key, amount
+        )
+
     async def set_active_battle(self, user_id: int, spectator_message_id: int, spectator_channel_id: int) -> None:
         """Record an active battle's spectator message so it can be cleaned up on restart."""
         await self.pool.execute(

--- a/cogs/views/towns.py
+++ b/cogs/views/towns.py
@@ -45,6 +45,35 @@ def build_on_enter_embed(location_info: dict, entry: dict, text: str) -> discord
     return embed
 
 
+class OnEnterContinueView(discord.ui.View):
+    """A single 'Continue' button attached to an on_enter ambient popup.
+
+    Lets an NPC named via an on_enter entry's `continue_npc` field speak
+    first — the player doesn't have to find and click a separate
+    "Talk to X" button. Reuses the same dialogue-resolution + action +
+    quest-progress pipeline as a normal talk button via
+    `parent_view._resolve_npc_dialogue`.
+    """
+    def __init__(self, parent_view, npc_id, npc_data):
+        super().__init__(timeout=180)
+        self.parent_view = parent_view
+        self.npc_id = npc_id
+        self.npc_data = npc_data
+
+    @discord.ui.button(label="Continue", style=discord.ButtonStyle.primary, emoji="➡️")
+    async def continue_button(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await interaction.response.defer()
+        log_list = await self.parent_view._resolve_npc_dialogue(self.npc_id, self.npc_data)
+        await self.parent_view._update_with_dialogue_log(log_list)
+        # Used up — disable the button on the ambient popup itself
+        for item in self.children:
+            item.disabled = True
+        try:
+            await interaction.edit_original_response(view=self)
+        except (discord.NotFound, discord.HTTPException):
+            pass
+
+
 class WildsView(discord.ui.View):
     def __init__(self, bot, original_interaction, location_id, activity_log: str = None):
         super().__init__(timeout=None)
@@ -484,16 +513,27 @@ class RemnantView(discord.ui.View):
         self.build_ui(time_of_day, player_flags, active_quest_ids, remnant)
         await interaction.edit_original_response(embed=new_embed, view=self)
 
+        # Track how many times this player has visited this sub-location —
+        # powers "visit_count" on_enter triggers (e.g. dwell-based escalation).
+        visit_counter_key = f"visits_{self.remnant_id}_{self.current_sub_location_id}"
+        visit_count = await db_cog.increment_counter(self.user_id, visit_counter_key)
+
         # on_enter — fire matching auto-dialogue as a separate ephemeral pop
         on_enter_match = await self._resolve_on_enter(
-            location_info, player_data, player_flags, time_of_day, db_cog
+            location_info, player_data, player_flags, time_of_day, db_cog, visit_count=visit_count
         )
         if on_enter_match:
             entry, text = on_enter_match
             on_enter_embed = build_on_enter_embed(location_info, entry, text)
-            await interaction.followup.send(embed=on_enter_embed, ephemeral=True)
+            continue_npc = entry.get('continue_npc')
+            if continue_npc:
+                npc_data = location_info.get('npcs', {}).get(continue_npc, {})
+                continue_view = OnEnterContinueView(self, continue_npc, npc_data)
+                await interaction.followup.send(embed=on_enter_embed, view=continue_view, ephemeral=True)
+            else:
+                await interaction.followup.send(embed=on_enter_embed, ephemeral=True)
 
-    async def _resolve_on_enter(self, location_info, player_data, player_flags, time_of_day, db_cog):
+    async def _resolve_on_enter(self, location_info, player_data, player_flags, time_of_day, db_cog, visit_count=None):
         """Check on_enter conditions and return (entry, text) for the first match, or None."""
         on_enter = location_info.get('on_enter', [])
         if not on_enter:
@@ -533,11 +573,37 @@ class RemnantView(discord.ui.View):
                 matched = time_of_day in self._DAY_PHASES
             elif condition == 'time:night':
                 matched = time_of_day in self._NIGHT_PHASES
+            elif condition == 'visit_count':
+                # Dwell/escalation trigger — fires once the player has
+                # visited this sub-location at least `min_count` times.
+                min_count = entry.get('min_count', 1)
+                if visit_count is not None:
+                    if once and flag:
+                        matched = visit_count >= min_count and flag not in player_flags
+                    else:
+                        matched = visit_count >= min_count
 
             if matched and text:
+                # Optional "chance": <0-1> — entry only fires probabilistically.
+                # On a miss, fall through to the next entry instead of going
+                # quiet entirely (and don't set flags / grant anything).
+                chance = entry.get('chance')
+                if chance is not None and random.random() > chance:
+                    continue
                 # Set flag if required (first_visit or once=True entries)
                 if flag and (condition == 'first_visit' or once):
                     await db_cog.set_flag(self.user_id, flag)
+                if entry.get('action') == 'grant_quest':
+                    quest_id = entry.get('quest_id')
+                    if quest_id:
+                        from data.quests import QUESTS
+                        quest_data = next(
+                            (d for town in QUESTS.values() for qid, d in town.items() if qid == quest_id), {}
+                        )
+                        initial_progress = {"status": "in_progress", "count": 0}
+                        if quest_data.get("time_sensitive"):
+                            initial_progress["ticks_remaining"] = quest_data.get("time_limit_ticks", 2)
+                        await db_cog.add_quest(self.user_id, quest_id, progress=initial_progress)
                 return entry, text
 
         return None
@@ -613,78 +679,91 @@ class RemnantView(discord.ui.View):
             await interaction.followup.send(embed=embed, ephemeral=True)
         return callback
 
+    async def _resolve_npc_dialogue(self, npc_id, fallback_npc_data=None):
+        """Resolves the NPC's current dialogue node, applies any
+        grant_item/grant_quest/complete_quest action, checks talk_npc quest
+        progress, and returns a log_list ready for _update_with_dialogue_log.
+
+        Shared by the "Talk to X" button (create_talk_callback) and the
+        on_enter "Continue" button (OnEnterContinueView), so an NPC can
+        deliver the same dialogue whether the player seeks them out or the
+        NPC speaks first on arrival."""
+        db_cog = self.bot.get_cog('Database')
+        node, dialogue_npc_data = await self._get_dialogue_node(npc_id)
+        npc_name = dialogue_npc_data.get('name', npc_id) if dialogue_npc_data else (fallback_npc_data or {}).get('name', npc_id)
+        log_list = []
+
+        if not node:
+            log_list.append(f"🗣️ **{npc_name}**\n*They have nothing to say to you right now.*")
+            return log_list
+
+        raw = node.get("text") or node.get("default", "...")
+        dialogue_text = random.choice(raw) if isinstance(raw, list) else raw
+        log_list.append(f"🗣️ **{npc_name}**\n*\"{dialogue_text}\"*")
+
+        if node.get("action") == "grant_item":
+            item_id = node.get("item_id")
+            quantity = node.get("quantity", 1)
+            if item_id:
+                await db_cog.add_item_to_inventory(self.user_id, item_id, quantity)
+                item_name = ITEMS.get(item_id, {}).get('name', 'an item')
+                log_list.append(f"🎁 **Received**\n*{quantity}× {item_name}*")
+
+        if node.get("action") == "grant_quest":
+            quest_id = node.get("quest_id")
+            from data.quests import QUESTS
+            quest_data = next(
+                (d for town in QUESTS.values() for qid, d in town.items() if qid == quest_id), {}
+            )
+            initial_progress = {"status": "in_progress", "count": 0}
+            if quest_data.get("time_sensitive"):
+                initial_progress["ticks_remaining"] = quest_data.get("time_limit_ticks", 2)
+            await db_cog.add_quest(self.user_id, quest_id, progress=initial_progress)
+            quest_title = quest_data.get('title', quest_id)
+            quest_desc  = quest_data.get('description', '')
+            quest_type  = quest_data.get('type', 'side')
+            grant_emoji = {'main': '⭐', 'assignment': '📋', 'side': '🔵', 'repeatable_bounty': '🔄'}.get(quest_type, '📜')
+            log_list.append(f"{grant_emoji} **New Quest: {quest_title}**\n*{quest_desc}*" if quest_desc
+                            else f"{grant_emoji} **New Quest: {quest_title}**")
+
+        if node.get("action") == "complete_quest":
+            quest_id = node.get("quest_id")
+            from data.quests import QUESTS
+            quest_data = next(
+                (d for town in QUESTS.values() for qid, d in town.items() if qid == quest_id), {}
+            )
+            required_item = node.get("required_item")
+            if required_item:
+                await db_cog.remove_item_from_inventory(self.user_id, required_item, 1)
+            await db_cog.complete_quest(self.user_id, quest_id)
+            await db_cog.set_flag(self.user_id, f"quest_{quest_id}_completed")
+            reward_item   = quest_data.get("reward_item")
+            reward_qty    = quest_data.get("reward_item_quantity", 1)
+            reward_coins  = quest_data.get("reward_coins", 0)
+            quest_title   = quest_data.get('title', quest_id)
+            if reward_item:
+                await db_cog.add_item_to_inventory(self.user_id, reward_item, reward_qty)
+                item_name = ITEMS.get(reward_item, {}).get('name', reward_item)
+                log_list.append(f"🎉 **Quest Complete: {quest_title}**\n*Reward: {reward_qty}× {item_name}*")
+            elif reward_coins:
+                await db_cog.update_player(self.user_id, coins=reward_coins)
+                log_list.append(f"🎉 **Quest Complete: {quest_title}**\n*Reward: {reward_coins} coins*")
+            else:
+                log_list.append(f"🎉 **Quest Complete: {quest_title}**")
+
+        quest_updates = await check_quest_progress(self.bot, self.user_id, "talk_npc", {"npc_id": npc_id},
+                                                   channel=self.parent_interaction.channel)
+        if quest_updates:
+            log_list.extend(quest_updates)
+
+        return log_list
+
     def create_talk_callback(self, npc_id, npc_data):
         """Full dialogue-tree talk handler — mirrors TownView.create_talk_callback,
         but updates the Remnant sub-location embed instead of a town one."""
         async def talk_callback(interaction: discord.Interaction):
             await interaction.response.defer()
-            db_cog = self.bot.get_cog('Database')
-            node, dialogue_npc_data = await self._get_dialogue_node(npc_id)
-            npc_name = dialogue_npc_data.get('name', npc_id) if dialogue_npc_data else npc_data.get('name', npc_id)
-            log_list = []
-
-            if not node:
-                log_list.append(f"🗣️ **{npc_name}**\n*They have nothing to say to you right now.*")
-            else:
-                raw = node.get("text") or node.get("default", "...")
-                dialogue_text = random.choice(raw) if isinstance(raw, list) else raw
-                log_list.append(f"🗣️ **{npc_name}**\n*\"{dialogue_text}\"*")
-
-                if node.get("action") == "grant_item":
-                    item_id = node.get("item_id")
-                    quantity = node.get("quantity", 1)
-                    if item_id:
-                        await db_cog.add_item_to_inventory(self.user_id, item_id, quantity)
-                        item_name = ITEMS.get(item_id, {}).get('name', 'an item')
-                        log_list.append(f"🎁 **Received**\n*{quantity}× {item_name}*")
-
-                if node.get("action") == "grant_quest":
-                    quest_id = node.get("quest_id")
-                    from data.quests import QUESTS
-                    quest_data = next(
-                        (d for town in QUESTS.values() for qid, d in town.items() if qid == quest_id), {}
-                    )
-                    initial_progress = {"status": "in_progress", "count": 0}
-                    if quest_data.get("time_sensitive"):
-                        initial_progress["ticks_remaining"] = quest_data.get("time_limit_ticks", 2)
-                    await db_cog.add_quest(self.user_id, quest_id, progress=initial_progress)
-                    quest_title = quest_data.get('title', quest_id)
-                    quest_desc  = quest_data.get('description', '')
-                    quest_type  = quest_data.get('type', 'side')
-                    grant_emoji = {'main': '⭐', 'assignment': '📋', 'side': '🔵', 'repeatable_bounty': '🔄'}.get(quest_type, '📜')
-                    log_list.append(f"{grant_emoji} **New Quest: {quest_title}**\n*{quest_desc}*" if quest_desc
-                                    else f"{grant_emoji} **New Quest: {quest_title}**")
-
-                if node.get("action") == "complete_quest":
-                    quest_id = node.get("quest_id")
-                    from data.quests import QUESTS
-                    quest_data = next(
-                        (d for town in QUESTS.values() for qid, d in town.items() if qid == quest_id), {}
-                    )
-                    required_item = node.get("required_item")
-                    if required_item:
-                        await db_cog.remove_item_from_inventory(self.user_id, required_item, 1)
-                    await db_cog.complete_quest(self.user_id, quest_id)
-                    await db_cog.set_flag(self.user_id, f"quest_{quest_id}_completed")
-                    reward_item   = quest_data.get("reward_item")
-                    reward_qty    = quest_data.get("reward_item_quantity", 1)
-                    reward_coins  = quest_data.get("reward_coins", 0)
-                    quest_title   = quest_data.get('title', quest_id)
-                    if reward_item:
-                        await db_cog.add_item_to_inventory(self.user_id, reward_item, reward_qty)
-                        item_name = ITEMS.get(reward_item, {}).get('name', reward_item)
-                        log_list.append(f"🎉 **Quest Complete: {quest_title}**\n*Reward: {reward_qty}× {item_name}*")
-                    elif reward_coins:
-                        await db_cog.update_player(self.user_id, coins=reward_coins)
-                        log_list.append(f"🎉 **Quest Complete: {quest_title}**\n*Reward: {reward_coins} coins*")
-                    else:
-                        log_list.append(f"🎉 **Quest Complete: {quest_title}**")
-
-                quest_updates = await check_quest_progress(self.bot, self.user_id, "talk_npc", {"npc_id": npc_id},
-                                                           channel=self.parent_interaction.channel)
-                if quest_updates:
-                    log_list.extend(quest_updates)
-
+            log_list = await self._resolve_npc_dialogue(npc_id, npc_data)
             await self._update_with_dialogue_log(log_list)
         return talk_callback
 
@@ -1289,7 +1368,7 @@ class TownView(discord.ui.View):
             on_enter_embed = build_on_enter_embed(location_info, entry, text)
             await interaction.followup.send(embed=on_enter_embed, ephemeral=True)
 
-    async def _resolve_on_enter(self, location_info, player_data, player_flags, time_of_day, db_cog):
+    async def _resolve_on_enter(self, location_info, player_data, player_flags, time_of_day, db_cog, visit_count=None):
         """Check on_enter conditions and return (entry, text) for the first match, or None."""
         on_enter = location_info.get('on_enter', [])
         if not on_enter:
@@ -1328,8 +1407,21 @@ class TownView(discord.ui.View):
                 matched = time_of_day in self._DAY_PHASES
             elif condition == 'time:night':
                 matched = time_of_day in self._NIGHT_PHASES
+            elif condition == 'visit_count':
+                # Dwell/escalation trigger — fires once the player has
+                # visited this sub-location at least `min_count` times.
+                min_count = entry.get('min_count', 1)
+                if visit_count is not None:
+                    if once and flag:
+                        matched = visit_count >= min_count and flag not in player_flags
+                    else:
+                        matched = visit_count >= min_count
 
             if matched and text:
+                # Optional "chance": <0-1> — entry only fires probabilistically.
+                chance = entry.get('chance')
+                if chance is not None and random.random() > chance:
+                    continue
                 if flag and (condition == 'first_visit' or once):
                     await db_cog.set_flag(self.user_id, flag)
                 return entry, text

--- a/data/dialogues.py
+++ b/data/dialogues.py
@@ -167,6 +167,17 @@ DIALOGUES = {
                  "Any luck? The pits look calm but they're not. Watch the Gloom Meter if you're heading back in.",
              ]},
 
+            # --- Guild training complete — handoff toward Weeping Chasm ---
+            # Flavor-only nudge toward the next leg of the journey (echoes_from_below).
+            # Doesn't gate or grant anything — just points the player at Kael.
+            {"required_flag": "quest_a_guildsmans_first_steps_completed",
+             "text": (
+                 "The road to Whisperwood runs through the Weeping Chasm first. Guild keeps "
+                 "a scholar out there — Kael. Good man, bit obsessive. He's been cataloguing "
+                 "things out there for years. If the Pits and the Chasm really do share a "
+                 "source like I think... he's the one who'd want to know what you've seen here."
+             )},
+
             # --- Tutorial step 7: offer the quest ---
             {"required_quest_step": {"quest_id": "a_guildsmans_first_steps", "step": 7},
              "action": "grant_quest", "quest_id": "sunk_cost",
@@ -222,6 +233,113 @@ DIALOGUES = {
                 "Soot was just a kit when I found him, near frozen at the edge of the ring. Same as the wild ones out there, more or less. He just happens to be mine.",
                 "Don't get many visitors out here. Most people see the ash and turn back before they even reach the shack.",
             ]},
+        ]
+    },
+
+    # -------------------------------------------------------------------------
+    # WARDEN ORIN — Guild Warden, Weeping Chasm. Manned during daylight hours.
+    # Terse, observational. Reports what he sees without elaborating on it.
+    # -------------------------------------------------------------------------
+    "warden_orin": {
+        "name": "Warden Orin", "role": "Guild Warden",
+        "dialogue_tree": [
+
+            # --- echoes_from_below completed ---
+            {"required_flag": "quest_echoes_from_below_completed",
+             "text": [
+                 "Kael still out there scribbling? Of course he is. Man doesn't know when to stop.",
+                 "You gave Kael what he needed, I take it. Good. Maybe he'll sleep for once.",
+                 "The records say the Gloom first surfaced here. I believe it. Some nights I can feel it thinking.",
+             ]},
+
+            # --- echoes_from_below active ---
+            {"required_quest_status": {"quest_id": "echoes_from_below", "status": "active"},
+             "text": [
+                 "This is as close as most people get. The Chasm draws Gloom-Touched creatures — they're drawn to the source. I keep watch so travelers can pass safely. Mostly.",
+                 "The east section of the wall is webbed over some mornings. Something large made that overnight. He doesn't elaborate. \"I don't go near it.\"",
+                 "Some mornings the mist is different. Heavier. Like something exhaled the whole of it at once. He says it the way you'd report weather.",
+                 "See that marker post? Cracked rune, tally marks scratched into the wood. Thirty-seven, last I counted. I didn't start that count. I just keep adding to it.",
+             ]},
+
+            # --- Default ---
+            {"default": "Road's passable. Mostly. Don't linger at the edge — the creatures here are drawn to the source and they don't watch where they're going."},
+        ]
+    },
+
+    # -------------------------------------------------------------------------
+    # LORE-KEEPER KAEL — Guild Scholar, Weeping Chasm. Obsessive, talks fast,
+    # already mid-thought when you arrive. Studies the Chasm as the Gloom's
+    # origin point. Quest giver/resolver for echoes_from_below.
+    # -------------------------------------------------------------------------
+    "lore_keeper_kael": {
+        "name": "Lore-Keeper Kael", "role": "Guild Scholar",
+        "dialogue_tree": [
+
+            # --- echoes_from_below completed — forward hook + lore in rotation ---
+            {"required_flag": "quest_echoes_from_below_completed",
+             "text": [
+                 "The density readings from your samples were unlike anything recorded further out. When you reach the Sunstone Oasis, find the Obsidian Monoliths. I'll be there. There's something I need to show you.",
+                 "Three samples told me more than three years of notes. Thank you for that — truly.",
+                 "It isn't shrinking. It's widening. I wish I had better news than that.",
+                 "Threnody's been restless since you brought those samples in. I don't think that's a coincidence.",
+             ]},
+
+            # --- Samples collected — turn-in ---
+            {"required_quest_step": {"quest_id": "echoes_from_below", "step": 1},
+             "text": (
+                 "These are clean samples — remarkable. The density here is unlike anything "
+                 "recorded further out. The Gloom didn't spread from a single point by accident. "
+                 "Every record points here — the Chasm — as the breach site. My theory: collective "
+                 "grief. A catastrophic loss, enough souls in enough pain at once to tear something "
+                 "open. The Guild doesn't like that theory. Too difficult to quantify. "
+                 "It isn't shrinking, by the way. It's widening. Thank you for this — truly."
+             )},
+
+            # --- Quest active, still collecting samples ---
+            {"required_quest_status": {"quest_id": "echoes_from_below", "status": "active"},
+             "text": [
+                 "You're here — good. I've been waiting for someone Vexia would actually trust with this. The origin point is right here and nobody bothers to study it properly. I need samples — three vials of gloom-mist from the Edge. Can you do that?",
+                 "Corrupted creatures can still be reached — the Gloom has touched them but hasn't consumed them. There's still something there to work with. Hollowed is different. When a creature Hollows, there's nothing left that remembers being a creature. That distinction matters. Remember it.",
+                 "Threnody — my Duskspinner. Named for a funeral song, after the Gloom's origin in collective sorrow. Yes, I know how that sounds. Ask me again sometime and I'll explain the etymology properly.",
+                 "He shows you a single research note: 'Specimen of unusual scale observed on east face. Preliminary classification impossible.' One entry. The next page is blank.",
+             ]},
+
+            # --- Default ---
+            {"default": "You found me. Good — I wasn't sure Vexia would send anyone capable."},
+        ]
+    },
+
+    # -------------------------------------------------------------------------
+    # "GRIM" GRETTA — Chasm Watcher, Lookout Hollow. Blunt, weathered, doesn't
+    # waste words. Keeps a half-bonded Threshling. Subdue-path perspective.
+    # -------------------------------------------------------------------------
+    "grim_gretta": {
+        "name": "\"Grim\" Gretta", "role": "Chasm Watcher",
+        "dialogue_tree": [
+
+            # --- echoes_from_below completed, Veteran rank or above ---
+            {"required_flag": "quest_echoes_from_below_completed",
+             "required_rank": "Veteran",
+             "text": "She looks you over once. Looks back at the fire. \"Still here.\" That's all she gives you. From Gretta, it means something."},
+
+            # --- echoes_from_below completed ---
+            {"required_flag": "quest_echoes_from_below_completed",
+             "text": [
+                 "Kael got his samples, then. Good. Maybe he'll stop wandering toward the edge at night.",
+                 "\"The breathing. You've heard it.\" Not a question. \"Don't go looking for what makes it.\"",
+                 "That creature following you — you trust it? The Gloom finds the ones you're attached to first. Keep it strong. Soft bonds don't survive this road.",
+             ]},
+
+            # --- echoes_from_below active ---
+            {"required_quest_status": {"quest_id": "echoes_from_below", "status": "active"},
+             "text": [
+                 "Guild sends another one. They always look the same — hopeful. The Chasm fixes that eventually. What do you want?",
+                 "\"Nothing worth finding out there.\"",
+                 "You want to know what I know? Fine. The Guild tells you to heal corrupted creatures. I've watched that fail more times than you've been alive. Control is not cruelty. It's honesty. There's another way — if you're willing to hear it.",
+             ]},
+
+            # --- Default ---
+            {"default": "Guild sends another one. They always look the same."},
         ]
     },
 }

--- a/data/explore_events.py
+++ b/data/explore_events.py
@@ -395,6 +395,37 @@ EXPLORE_EVENTS = {
             ],
         },
 
+        # --- Quest: echoes_from_below ---
+        # Only appears in the explore pool while the quest is active.
+        {
+            "type": "choice",
+            "weight": 8,
+            "required_quest_active": "echoes_from_below",
+            "text": (
+                "Gloom-mist pools in a hollow in the rock here, denser than the air "
+                "around it — thick enough that it almost holds its shape. "
+                "One of Kael's empty sample vials sits heavy in your pack."
+            ),
+            "choices": [
+                {
+                    "label": "Fill a sample vial",
+                    "emoji": "🧪",
+                    "text": (
+                        "You uncap one of Kael's vials and let the mist pour in. It moves "
+                        "slower than mist should, settling like liquid. The glass fogs "
+                        "over immediately and stays that way."
+                    ),
+                    "outcome": {"item": {"item_id": "gloom_mist_sample", "qty": 1}},
+                },
+                {
+                    "label": "Walk past",
+                    "emoji": "🚶",
+                    "text": "You leave it be. Whatever it is, it isn't going anywhere.",
+                    "outcome": {},
+                },
+            ],
+        },
+
         # --- Apex Lore Events (Chasmbane + Veilmother) ---
         # These are atmosphere/scare events — no battle, no capture.
         # Full rank-gated encounter logic tagged for later.

--- a/data/items.py
+++ b/data/items.py
@@ -472,6 +472,34 @@ ITEMS = {
         "price": 0,
         "actions": ["inspect"],
     },
+    "kaels_field_notes": {
+        "name": "Kael's Field Notes",
+        "description": (
+            "A hand-copied set of pages from Lore-Keeper Kael's research journal, given "
+            "to you as thanks for the gloom-mist samples. Dense, careful handwriting — "
+            "theories about the Chasm, the Gloom, and what's worth remembering."
+        ),
+        "dropdown_description": "Lore item from Lore-Keeper Kael.",
+        "menu_description": "Kael's notes on the Gloom's origin. Read to learn what he's found.",
+        "category": "Lore Items",
+        "price": 0,
+        "actions": ["inspect", "drop"],
+        "lore_text": (
+            "**Field Notes — L. Kael, Weeping Chasm Survey**\n\n"
+            "*On the origin:*\n"
+            "The Gloom didn't spread from a single point by accident. Every record points "
+            "here — the Chasm — as the breach site. My working theory: collective grief. "
+            "A catastrophic loss, enough souls in enough pain at once to tear something "
+            "open. The Guild doesn't like that theory. Too difficult to quantify.\n\n"
+            "*On the Hollowed:*\n"
+            "Corrupted creatures can still be reached — the Gloom has touched them but "
+            "hasn't consumed them. There's still something there to work with. Hollowed "
+            "is different. When a creature Hollows, there's nothing left that remembers "
+            "being a creature. That distinction matters. Remember it.\n\n"
+            "*Last line, underlined twice:*\n"
+            "*'It isn't shrinking. It's widening.'*"
+        ),
+    },
     "waystation_ledger": {
         "name": "Waystation Ledger",
         "description": (

--- a/data/quests.py
+++ b/data/quests.py
@@ -135,6 +135,37 @@ QUESTS = {
     },
 
     # ------------------------------------------------------------------
+    # WEEPING CHASM — echoes_from_below
+    # Granted automatically on first visit to The Chasm's Edge.
+    # Resolves entirely on-site with Lore-Keeper Kael at the Scholar's Camp.
+    # ------------------------------------------------------------------
+    "weeping_chasm": {
+        "echoes_from_below": {
+            "title": "Echoes From Below",
+            "description": (
+                "Lore-Keeper Kael, camped near the Chasm's Edge, believes the Weeping "
+                "Chasm is the source of the Gloom itself. He needs samples of the "
+                "gloom-mist gathering in the rock hollows to study it properly."
+            ),
+            "type": "main",
+            "objectives": [
+                {
+                    "text": "Collect 3 `Gloom-mist Sample` vials from the Chasm's Edge.",
+                    "type": "item_pickup", "target": "gloom_mist_sample",
+                    "required_count": 3, "zone": "weeping_chasm"
+                },
+                {
+                    "text": "Bring the samples to Lore-Keeper Kael at the Scholar's Camp.",
+                    "type": "talk_npc", "target": "lore_keeper_kael"
+                }
+            ],
+            "reward_reputation": 30,
+            "reward_item": "kaels_field_notes",
+            "reward_item_quantity": 1
+        }
+    },
+
+    # ------------------------------------------------------------------
     # ASHEN VERGE — Kaelen's repeatable boundary-culling bounty
     # ------------------------------------------------------------------
     "ashenVerge": {

--- a/data/remnants.py
+++ b/data/remnants.py
@@ -72,15 +72,41 @@ REMNANTS = {
                     {
                         "condition": "first_visit",
                         "flag": "visited_chasms_edge",
+                        "action": "grant_quest",
+                        "quest_id": "echoes_from_below",
+                        "footer": "⭐ New Quest: Echoes From Below",
                         "text": (
                             "The cold hits before you reach the rim. Your pet stops a full "
                             "step behind you and won't come closer. From below — not wind, "
                             "not echo — something like breathing."
                         ),
                     },
+                    # --- Beat 4: "The Breathing" — dwell-based escalation ---
+                    # Fires once, the first time the player visits the Edge
+                    # for at least the 5th time. A scare, not a fight — the
+                    # Chasmbane itself stays out of sight for now. Placed
+                    # ahead of the night-mist ambient so it isn't crowded out
+                    # once it becomes eligible.
+                    {
+                        "condition": "visit_count",
+                        "min_count": 5,
+                        "once": True,
+                        "flag": "chasm_breathing_event_seen",
+                        "footer": "Something noticed you.",
+                        "text": (
+                            "You've lost count of how many times you've stood here. "
+                            "This time the breathing doesn't stop when you arrive — "
+                            "it gets louder. Closer. For one long moment the mist "
+                            "below rolls back, like something vast just shifted in "
+                            "the dark and pushed it aside.\n\n"
+                            "Then it's gone. The mist settles back over the hollow. "
+                            "Your pet doesn't move for a long time."
+                        ),
+                    },
                     {
                         "condition": "time:night",
                         "once": False,
+                        "chance": 0.4,
                         "text": (
                             "*The mist curls upward around your ankles. "
                             "Nothing attacks. Something is just checking.*"
@@ -112,11 +138,8 @@ REMNANTS = {
                     {
                         "condition": "first_visit",
                         "flag": "visited_wardens_post",
-                        "text": (
-                            "Orin glances up from his logbook. *\"Road's passable. "
-                            "Mostly. Don't linger at the edge — the creatures here "
-                            "are drawn to the source and they don't watch where they're going.\"*"
-                        ),
+                        "continue_npc": "warden_orin",
+                        "text": "Orin glances up from his logbook, sets it aside.",
                     },
                     {
                         "condition": "flag:quest_a_guildsmans_first_steps_completed",
@@ -147,31 +170,6 @@ REMNANTS = {
                             ),
                             "player_species_reactions": {},
                         },
-                        "dialogue": {
-                            "default": (
-                                "This is as close as most people get. The Chasm draws "
-                                "Gloom-Touched creatures — they're drawn to the source. "
-                                "I keep watch so travelers can pass safely. Mostly."
-                            ),
-                            "lore_prompt": (
-                                "The records say The Gloom first surfaced here. I believe it. "
-                                "Some nights I can feel it thinking."
-                            ),
-                            "returning_recruit": (
-                                "Ah — a Guild recruit. Good. The road east gets worse before "
-                                "it gets better. Keep your pet fed and your energy up."
-                            ),
-                            "lore_east_wall": (
-                                "*\"The east section of the wall is webbed over some mornings. "
-                                "Something large made that overnight.\"* "
-                                "He doesn't elaborate. *\"I don't go near it.\"*"
-                            ),
-                            "lore_breathing": (
-                                "*\"Some mornings the mist is different. Heavier. "
-                                "Like something exhaled the whole of it at once.\"* "
-                                "He says it the way you'd report weather."
-                            ),
-                        },
                     },
                 },
             },
@@ -196,12 +194,8 @@ REMNANTS = {
                     {
                         "condition": "first_visit",
                         "flag": "visited_scholars_camp",
-                        "text": (
-                            "Kael looks up immediately, already talking. "
-                            "*\"You're here — good. I've been waiting for someone "
-                            "Vexia would actually trust with this. "
-                            "The origin point is right here and nobody studies it properly.\"*"
-                        ),
+                        "continue_npc": "lore_keeper_kael",
+                        "text": "Kael looks up immediately, already talking.",
                     },
                 ],
                 "services": {},
@@ -229,40 +223,6 @@ REMNANTS = {
                                 ),
                             },
                         },
-                        "dialogue": {
-                            "default": (
-                                "You found me. Good — I wasn't sure Vexia would send anyone "
-                                "capable. The origin point is right here and nobody bothers "
-                                "to study it properly. I need samples. Three vials of "
-                                "gloom-mist from the Edge. Can you do that?"
-                            ),
-                            "samples_collected": (
-                                "These are clean samples — remarkable. The density here is "
-                                "unlike anything recorded further out. When you reach the "
-                                "Oasis, find the Obsidian Monoliths. I'll be there. "
-                                "There's something I need to show you."
-                            ),
-                            "lore_gloom_origin": (
-                                "The Gloom didn't spread from a single point by accident. "
-                                "Every record points here — the Chasm — as the breach site. "
-                                "My theory: collective grief. A catastrophic loss, enough "
-                                "souls in enough pain at once to tear something open. "
-                                "The Guild doesn't like that theory. Too difficult to quantify."
-                            ),
-                            "lore_hollowed_vs_corrupted": (
-                                "Corrupted pets can still be reached — the Gloom has touched "
-                                "them but hasn't consumed them. There's still something there "
-                                "to work with. Hollowed is different. When a creature Hollows, "
-                                "there's nothing left that remembers being a creature. "
-                                "That distinction matters. Remember it."
-                            ),
-                            "lore_east_wall": (
-                                "He shows you a single research note. "
-                                "*'Specimen of unusual scale observed on east face. "
-                                "Preliminary classification impossible.'* "
-                                "One entry. The next page is blank."
-                            ),
-                        },
                     },
                 },
             },
@@ -287,11 +247,8 @@ REMNANTS = {
                     {
                         "condition": "first_visit",
                         "flag": "visited_lookout_hollow",
-                        "text": (
-                            "Gretta looks up from the fire. Takes you in once, top to bottom. "
-                            "*\"Guild sends another one.\"* She looks back at the fire. "
-                            "*\"They always look the same.\"*"
-                        ),
+                        "continue_npc": "grim_gretta",
+                        "text": "Gretta looks up from the fire. Takes you in once, top to bottom.",
                     },
                     {
                         "condition": "has_pet_species:Threshling",
@@ -335,38 +292,6 @@ REMNANTS = {
                                 "It stays because she makes it stay."
                             ),
                             "player_species_reactions": {},
-                        },
-                        "dialogue": {
-                            "default": (
-                                "Guild sends another one. They always look the same — "
-                                "hopeful. The Chasm fixes that eventually. "
-                                "What do you want?"
-                            ),
-                            "player_has_pet": (
-                                "That creature following you — you trust it? "
-                                "The Gloom finds the ones you're attached to first. "
-                                "Keep it strong. Soft bonds don't survive this road."
-                            ),
-                            "subdue_path_intro": (
-                                "You want to know what I know? Fine. "
-                                "The Guild tells you to heal corrupted creatures. "
-                                "I've watched that fail more times than you've been alive. "
-                                "Control is not cruelty. It's honesty. "
-                                "There's another way — if you're willing to hear it."
-                            ),
-                            "lore_deep_chasm": (
-                                "*\"Nothing worth finding out there.\"*"
-                            ),
-                            "lore_deep_chasm_pressed": (
-                                "She looks at you for a long moment. "
-                                "*\"The breathing. You've heard it. "
-                                "Don't go looking for what makes it.\"*"
-                            ),
-                            "returning_high_rank": (
-                                "She looks you over once. Looks back at the fire. "
-                                "*\"Still here.\"* That's all she gives you. "
-                                "From Gretta, it means something."
-                            ),
                         },
                     },
                 },

--- a/docs/design/world/aethelgard_classification.md
+++ b/docs/design/world/aethelgard_classification.md
@@ -54,12 +54,26 @@ Ordinary → Prime → Apex → **Elder** → **Ancient** → Primordial → Ete
 
 ## 2. Encounter Rarity
 
-Common → Uncommon → Rare → (further tiers TBD as needed)
+Normal → Odd → Rare → Peculiar → Strange → Uncanny → Unknown
 
-This is the **familiar rarity language**, but it now describes *sighting frequency*, not
-power level. It's the term Guilds, NPCs, and players would actually use day-to-day —
-"there's a rare sighting of an ordinary pet out near the Thicket" is a complete, useful
-sentence that doesn't require the listener to know anything about Classification Tiers.
+(Implemented in `data/classifications.py` as `ENCOUNTER_RARITIES` /
+`ENCOUNTER_RARITY_WEIGHTS`, superseding the original "Common → Uncommon → Rare →
+TBD" sketch above.)
+
+This is the **rarity language for sightings** — describing how surprising it is to see
+*this* (species, possibly Gloom-marked) at *this* location, not power level. It's the term
+Guilds, NPCs, and players would actually use day-to-day — "there's an odd sighting of an
+ordinary pet out near the Thicket" is a complete, useful sentence that doesn't require the
+listener to know anything about Classification Tiers.
+
+`Unknown` is intentionally reserved for story/quest-triggered encounters, not the general
+wild-encounter pool — it reads as "this shouldn't be happening at all."
+
+**This is now the *only* "rarity" — the old per-species `rarity` field (Starter / Common /
+Uncommon / Rare / Ancient / "Very Rare") on `PET_DATABASE` entries is being discarded.**
+Classification Tier (Section 1) is what "rarity" meant for a *species*; Encounter Rarity
+(this section) is what "rarity" means for a *sighting*. See
+`world/pets_rarity_cleanup.md` for the cleanup this implies.
 
 **Why this split matters:**
 - A creature's Classification Tier rarely changes. Its Encounter Rarity can shift based on

--- a/docs/design/world/next_world_segment.md
+++ b/docs/design/world/next_world_segment.md
@@ -1,0 +1,77 @@
+# Aethelgard — Next World Segment (Notes, Pre-Brainstorm)
+
+Status: NOTES — captured findings, brainstorm not yet started. Picks up after the
+Weeping Chasm / Mirefields / Whisperwood pass + `implementation_roadmap.md`.
+
+---
+
+## What Exists in Code Today
+
+- **Town 3 = Sunstone Oasis** (`data/towns.py`, key `sunstoneOasis`, rank
+  "Journeyman", desert flavor — morning/noon/evening/night descriptions written,
+  but `locations: {}` and `connections: {'whisperwoodGrove': 'Whisperwood Grove'}`
+  only). Equivalent stage to a blank `whisperwood_grove.md` before that pass —
+  no NPCs, shop, or lore yet.
+
+- **Between Whisperwood Grove and Sunstone Oasis = "The Glade of Whispers"**
+  (`data/remnants.py`, key `glade_of_whispers`, `between: ['whisperwoodGrove',
+  'sunstoneOasis']`). More fleshed than other stub remnants (12 keys vs 8 —
+  already has a `connections` field). Description sets up a deliberate tonal
+  contrast vs. everything else in Aethelgard so far:
+
+  > "A small, perfectly circular glade where sunlight filters through a natural
+  > opening in the canopy. The air hums faintly — not with danger, but with
+  > something older and calmer. Flowers here bloom year-r[ound]..."
+
+- **Larger map skeleton already sketched** (all placeholder `between` pairs,
+  generic names, `availability: all`/`day`, minimal fields — basically an
+  overworld graph waiting to be filled in, not relevant yet but good to know
+  it exists):
+  - `obsidian_monoliths` — between `sunstoneOasis` & `ironforge`
+  - `shifting_dunes` — between `sunstoneOasis` & `aethelgardsRest`
+  - `lost_guild_hall` — between `frostfallPeak` & `blackwaterMarsh`
+  - `sunken_ship_graveyard` — between `aethelgardsRest` & `skylightSpire`
+  - `wyrmwood_forest` — between `blackwaterMarsh` & `ironforge` ("The Gloom runs
+    deep here")
+  - `cloudspire_outpost` — between `skylightSpire` & `silvermoonGlade`
+  - `scholars_retreat` — between `silvermoonGlade` & `sunkenCity` (library,
+    "collection inside spans centuries of Aethelgard's history")
+  - `chasm_of_whispers` — between `ironforge` & `skylightSpire`
+  - `forgotten_grove` — between `blackwaterMarsh` & `ironforge` (inside
+    Wyrmwood Forest, "miraculously resisted the Gloom")
+  - `serpents_coil` — between `sunkenCity` & `dragonsTooth`
+
+  None of these future towns (`ironforge`, `aethelgardsRest`, `blackwaterMarsh`,
+  `frostfallPeak`, `skylightSpire`, `silvermoonGlade`, `sunkenCity`,
+  `dragonsTooth`) exist in `TOWNS` yet.
+
+---
+
+## Suggested Next Step (when we pick this up)
+
+Mirrors the Oakhaven → Whisperwood pattern: **the remnant *between* the current
+frontier town and the next town gets a main story first.**
+
+1. **The Glade of Whispers — main story pass** (same story-first approach as
+   Weeping Chasm/Mirefields). Bridges Whisperwood Grove → Sunstone Oasis.
+2. **Sunstone Oasis — Town 3 core design** (NPCs, shop, locations, lore) — the
+   bigger "Whisperwood Grove-sized" pass, after or alongside #1.
+
+### Why Glade of Whispers is an interesting seed
+
+- Its "calm, no danger" framing is a natural place to finally use one of the
+  still-unused Gloom Frames from `aethelgard_gloom_frames.md` (Seeker,
+  Liberationist, Fatalist) — or even introduce something **not** Gloom-touched
+  at all, a real tonal break after every other remnant has been Gloom-inflected.
+- Could be a resting point for the "Probably" / Anora thread (Weeping Chasm) —
+  a quiet, ambiguous place fits an unresolved "what happened to her" beat.
+
+---
+
+## Cross-References
+
+- `world/implementation_roadmap.md` — current build-order for Layers 1-4
+  (Weeping Chasm/Mirefields/Whisperwood). This segment comes *after* that.
+- `world/aethelgard_gloom_frames.md` — Seeker/Liberationist/Fatalist frames,
+  flagged there as "future remnant" seeds.
+- `world/aethelgard_world_connections.md` — "Probably" / Anora thread.

--- a/docs/design/world/next_world_segment.md
+++ b/docs/design/world/next_world_segment.md
@@ -47,6 +47,40 @@ Weeping Chasm / Mirefields / Whisperwood pass + `implementation_roadmap.md`.
 
 ---
 
+## Other Loose Threads That Touch This Segment
+
+- **`data/towns.py` comment says "TOWN 3 — Sunstone Oasis (stub, unlocked after
+  Verdant Crest)"**. "Verdant Crest" doesn't match any current town name
+  (Whisperwood Grove is the actual predecessor). Likely a leftover/older name
+  from before the remnant naming settled — flag and resolve (or just update the
+  comment) when this segment starts.
+
+- **`data/wandering_npcs.py`** already has a placeholder road entry:
+  `"whisperwoodGrove__sunstoneOasis"`, commented "stub — fill in when Town 3 is
+  built." Wandering NPCs for this road are part of the Town 3 batch.
+
+- **`utils/constants.py`** — "The Ember Crest" achievement is already written
+  and tied to Sunstone Oasis: *"Earned in Sunstone Oasis, it symbolizes an
+  Adventurer's ability to master powerful Fire-type companions and endure the
+  scorching heat of the desert."* This pins Sunstone Oasis as a **Fire-type
+  hub** — useful constraint when designing its pets/NPCs/shop.
+
+- **Forward hooks already planted from Weeping Chasm** point straight at this
+  segment — continuity is already half-built:
+  - `weeping_chasm/echoes_from_below_quest.md`, Beat 5.5 ("Forward Hook,
+    stretch") — Kael's hook points toward "Obsidian Monoliths/Sunstone Oasis."
+  - `weeping_chasm/weeping_chasm_v2.md` — reward note: "forward hook to
+    Obsidian Monoliths / Sunstone Oasis."
+  - `weeping_chasm/archive/weeping_chasm.md` (superseded, but for reference) —
+    "Kael disappears from the Chasm. Thread dangles toward Sunstone Oasis."
+
+  When this segment starts, check whether Kael's forward hook (Layer 1a) should
+  resolve *into* the Glade of Whispers / Sunstone Oasis story, or stay a
+  separate dangling thread for later (Obsidian Monoliths is one stop further,
+  between Sunstone Oasis and the not-yet-built `ironforge`).
+
+---
+
 ## Suggested Next Step (when we pick this up)
 
 Mirrors the Oakhaven → Whisperwood pattern: **the remnant *between* the current

--- a/docs/design/world/pets_rarity_cleanup.md
+++ b/docs/design/world/pets_rarity_cleanup.md
@@ -1,0 +1,100 @@
+# Pets — Rarity Field Cleanup (Story Pass → Code Pass Handoff)
+
+Status: LOCKED on intent (per Kyle), implementation not started.
+
+---
+
+## The Model (clarified)
+
+There used to be one "rarity" stat. `aethelgard_classification.md` split it into two
+axes: **Classification Tier** (what a creature *is*) and **Encounter Rarity** (how often
+it's *seen*, in context).
+
+What actually happened during the recent `classification_tier`/`encounter_rarity`
+migration: `classification_tier` was added to every `PET_DATABASE` entry, and
+`ENCOUNTER_TABLES` were migrated to per-location `encounter_rarity`. **But the old
+per-species `rarity` field (`Starter` / `Common` / `Uncommon` / `Rare` / `Ancient` /
+`"Very Rare"`) was left in place alongside it** — so right now every pet carries both an
+old-style `rarity` and a new `classification_tier`, and several places in the code still
+read the old field. That's the miscommunication this doc is closing:
+
+> **`classification_tier` IS the rarity, for a species.** The old `rarity` field on
+> `PET_DATABASE` is to be discarded. "Rarity" as a word now belongs to
+> `encounter_rarity` only (per-location sighting frequency, Section 2 of
+> `aethelgard_classification.md`).
+
+---
+
+## Confirmed: `rarity` ↔ `classification_tier` Mapping (for reference during removal)
+
+| old `rarity` | `classification_tier` | Count | Notes |
+|---|---|---|---|
+| Common | Ordinary | 8 | |
+| Uncommon | Prime | 16 | |
+| Rare | Apex | 11 | |
+| Ancient | Elder | 6 | Veilmother, Aberraflora, Verdanthorn, Cindermaw, Pyrehart, Threshbound |
+| Starter | Ordinary / Prime / Apex (per evolution stage) | 9 | Pyrelisk/Dewdrop/Terran lines |
+| **"Very Rare"** | Elder | 1 | **Mirewarden** — confirmed stale, "Very Rare" isn't used anymore. Once `rarity` is removed this is moot, but if anything reads it before then, treat as `Ancient`. |
+| Common | **Apex** | 1 | **Stillroot** — the one real outlier (see below). |
+
+### Stillroot — needs a decision
+
+Stillroot's `classification_tier` was deliberately bumped to `Apex` (so its unique
+Stonecrust passive isn't overridden by the shared type-passive pool — see inline comment
+in `data/pets.py`), but its old `rarity` stayed `Common`. Once `rarity` is gone, Stillroot
+is just `Apex` tier like any other Apex creature — **is that correct**, or was the
+"Common-but-mechanically-special" framing meant to persist some other way (e.g. a
+specific `encounter_rarity` entry for Stillroot in the `weepingRoot` table — which already
+exists and is separately tagged "Rare" per the classification doc's own example)?
+Likely fine to just let Stillroot be `Apex` + whatever `encounter_rarity` its table entry
+already has — flagging so it's a conscious choice, not a silent side effect.
+
+---
+
+## What Reads the Old `rarity` Field Today
+
+| File | Usage | What replaces it |
+|---|---|---|
+| `cogs/game.py:17` | `STARTER_PETS_LIST = [pet for pet in PET_DATABASE.values() if pet.get('rarity') == 'Starter']` | **Needs a new mechanism** — `rarity` is the *only* place "this is a starter line" is recorded. Suggest a small `STARTER_SPECIES` list (the 3 species keys: Pyrelisk/Dewdrop/Terran) or an `is_starter: True` flag on those 3 top-level entries only (not their evolutions). |
+| `cogs/adventure.py:254` | Legacy fallback: `wild_pet_base['rarity'] in ["Common", "Uncommon"]` for shared-passive-pool decision, only used `if classification_tier is None` | **Dead code** — every pet now has `classification_tier`. Safe to delete the fallback branch (and the `else`). |
+| `cogs/adventure.py:279` | Copies `rarity` into the wild pet instance dict | Drop, or copy `classification_tier` instead if instances need it downstream. |
+| `cogs/admin.py:136` | Copies `rarity` into a pet instance dict (admin pet-grant tool) | Same as above. |
+| `cogs/search.py:62-64,177-178` | `RARITY_EMOJIS` dict (`Starter/Common/Uncommon/Rare/Epic/Legendary`) keyed by `data.get("rarity", "Common")` | Rebuild keyed by `classification_tier` (`Ordinary/Prime/Apex/Elder/Ancient/Primordial/Eternal`). Note `Epic`/`Legendary` were never actual values — drop them. |
+| `cogs/views/character.py:374-377` | `rarity_colors` dict (`Starter/Common/Uncommon/Rare/Legendary`) keyed by `pet.rarity` | Same — rebuild keyed by `classification_tier`. This is also where the **Ancient-tier display gap** gets fixed (Veilmother/Verdanthorn/etc. currently fall back to plain grey). |
+
+### Already-dead, unrelated but found during this pass
+
+- `utils/constants.py` — `PET_EVOLUTIONS` (references nonexistent species `"Verdant
+  Golem"`) and `XP_REWARD_BY_RARITY` (`Common/Uncommon/Rare/Legendary`) are both fully
+  unreferenced anywhere in `cogs/`/`utils/`. Safe to delete as part of the same pass
+  (or separately — they're unrelated to the `rarity` field itself, just dead weight in the
+  same file family).
+
+---
+
+## Suggested Cleanup Order (for a code session)
+
+1. Add a starter-line marker that doesn't depend on `rarity` (e.g. `STARTER_SPECIES =
+   ["Pyrelisk", "Dewdrop", "Terran"]` somewhere central, or `is_starter: True` on those 3
+   entries). Update `cogs/game.py:17`.
+2. Rebuild `RARITY_EMOJIS` (`cogs/search.py`) and `rarity_colors`
+   (`cogs/views/character.py`) keyed on `classification_tier`, covering all 7 tiers
+   (Ordinary/Prime/Apex/Elder/Ancient/Primordial/Eternal — even if Primordial/Eternal have
+   no pets yet, define a fallback so future additions don't silently render wrong).
+3. Remove `rarity` from every `PET_DATABASE` entry (base + evolutions).
+4. Remove the dead legacy-fallback branch in `cogs/adventure.py` (`use_shared_passive`
+   `else` arm) and the `rarity` copies in `cogs/adventure.py`/`cogs/admin.py` instance
+   dicts.
+5. Delete `PET_EVOLUTIONS` and `XP_REWARD_BY_RARITY` from `utils/constants.py`.
+6. Resolve Stillroot per the decision above (likely: no special-case needed, just confirm).
+
+---
+
+## Cross-References
+
+- `world/aethelgard_classification.md` — Section 1 (Classification Tier) and Section 2
+  (Encounter Rarity, updated alongside this doc to reflect the actual implemented
+  `Normal/Odd/Rare/Peculiar/Strange/Uncanny/Unknown` scale).
+- `data/classifications.py` — `CLASSIFICATION_TIERS`, `ENCOUNTER_RARITIES`,
+  `ENCOUNTER_RARITY_WEIGHTS`.
+- `data/pets.py` — `PET_DATABASE`, `ENCOUNTER_TABLES`.

--- a/migrations/012_add_player_counters.py
+++ b/migrations/012_add_player_counters.py
@@ -1,0 +1,21 @@
+# migrations/012_add_player_counters.py
+
+async def apply(cursor):
+    """
+    Migration 012: Adds a generic per-player counter table.
+
+    Used for tracking arbitrary numeric progress that doesn't fit the
+    boolean player_flags table — e.g. how many times a player has visited
+    a specific location (for dwell/visit-based on_enter triggers), how
+    many times they've rested somewhere, repeatable-task tallies, etc.
+
+    Each (player_id, counter_key) pair holds a single integer value.
+    """
+    await cursor.execute("""
+        CREATE TABLE IF NOT EXISTS player_counters (
+            player_id BIGINT NOT NULL,
+            counter_key TEXT NOT NULL,
+            value INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (player_id, counter_key)
+        )
+    """)


### PR DESCRIPTION
## Summary
- New main quest **Echoes From Below**: collect 3 gloom-mist samples at the Chasm's Edge and report to Lore-Keeper Kael, rewarding Kael's Field Notes + reputation.
- Wired Galen, Warden Orin, Lore-Keeper Kael, and "Grim" Gretta dialogue across quest beats (pre-quest, active, and post-completion lines).
- Added `gloom_mist_sample` collection via a quest-gated explore choice event, and fixed two latent quest-progress bugs:
  - multi-count `item_pickup` objectives no longer stop dropping after the first item
  - choice-event item rewards now advance quest progress
- Added `grant_quest` support to `on_enter` entries (resolves the Scholar's Camp quest-gate circularity).
- New "ambient/alive" template for NPC locations:
  - chance-based `on_enter` triggers (not every condition match fires)
  - `continue_npc` + "Continue" button — NPCs can speak first on arrival, reusing the full dialogue-tree/action/quest-progress pipeline
  - generic `player_counters` table + `visit_count` on_enter trigger, used for a one-time "Breathing" escalation event at the Chasm's Edge after repeated visits
- Removed dead flat `dialogue` dicts now superseded by `DIALOGUES` trees.

## Test plan
- [ ] First visit to Chasm's Edge grants Echoes From Below (footer label shown)
- [ ] Exploring Chasm's Edge while quest is active can yield gloom-mist samples (stacks to 3)
- [ ] Visiting Scholar's Camp with quest active unlocks the location and Kael's Continue dialogue
- [ ] Turning in samples to Kael completes the quest, grants Kael's Field Notes + reputation
- [ ] Post-completion dialogue updates for Orin, Kael, and Gretta
- [ ] Warden's Post / Lookout Hollow show a "Continue" button on first visit and deliver NPC dialogue
- [ ] 5th+ visit to Chasm's Edge triggers the one-time "Breathing" event
- [ ] DB migration 012 applies cleanly (player_counters table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)