### PR TITLE
Replace per-pet rarity field with classification_tier system

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -133,7 +133,7 @@ class Admin(commands.Cog):
                             base_stats}
 
         wild_pet = {
-            "species": pet_base_data['species'], "rarity": pet_base_data['rarity'],
+            "species": pet_base_data['species'], "classification_tier": pet_base_data['classification_tier'],
             "pet_type": pet_base_data['pet_type'],
             "level": level, "current_hp": calculated_stats['hp'], "max_hp": calculated_stats['hp'],
             "attack": calculated_stats['attack'], "defense": calculated_stats['defense'],

--- a/cogs/adventure.py
+++ b/cogs/adventure.py
@@ -255,13 +255,8 @@ class Adventure(commands.Cog):
                 # Pet generation logic (stats, passive, skills)
                 # Ordinary/Prime tier species draw from the shared type-based
                 # passive pool; Apex and above keep their unique passive.
-                # Falls back to the legacy rarity check for species not yet
-                # migrated to classification_tier.
-                classification_tier = wild_pet_base.get('classification_tier')
-                if classification_tier is not None:
-                    use_shared_passive = classification_tier in ("Ordinary", "Prime")
-                else:
-                    use_shared_passive = wild_pet_base['rarity'] in ["Common", "Uncommon"]
+                classification_tier = wild_pet_base['classification_tier']
+                use_shared_passive = classification_tier in ("Ordinary", "Prime")
 
                 assigned_passive = None
                 if use_shared_passive:
@@ -286,7 +281,7 @@ class Adventure(commands.Cog):
                             all_learnable_skills.append(random.choice(skills['choice']))
                 active_skills = all_learnable_skills[-4:] if all_learnable_skills else ["pound"]
                 wild_pet_instance = {
-                    "species": wild_pet_base['species'], "rarity": wild_pet_base['rarity'],
+                    "species": wild_pet_base['species'], "classification_tier": wild_pet_base['classification_tier'],
                     "pet_type": wild_pet_base['pet_type'], "level": level,
                     "personality": wild_pet_base.get('personality', 'Aggressive'),
                     "current_hp": calculated_stats['hp'], "max_hp": calculated_stats['hp'],

--- a/cogs/database.py
+++ b/cogs/database.py
@@ -231,7 +231,7 @@ class Database(commands.Cog):
         return [row['recipe_id'] for row in records]
 
     # --- Pet Management ---
-    async def add_pet(self, owner_id: int, name: str, species: str, description: str, rarity: str, pet_type: any,
+    async def add_pet(self, owner_id: int, name: str, species: str, description: str, classification_tier: str, pet_type: any,
                       skills: list, current_hp: int, max_hp: int, attack: int, defense: int, special_attack: int,
                       special_defense: int, speed: int, base_hp: int, base_attack: int, base_defense: int,
                       base_special_attack: int, base_special_defense: int, base_speed: int,
@@ -246,14 +246,14 @@ class Database(commands.Cog):
 
         skills_json = json.dumps(skills if skills else [])
         pet_type_to_save = json.dumps(pet_type) if isinstance(pet_type, list) else pet_type
-        query = '''INSERT INTO pets (player_id, name, species, description, rarity, pet_type, skills,
+        query = '''INSERT INTO pets (player_id, name, species, description, classification_tier, pet_type, skills,
                                      current_hp, max_hp, attack, defense, special_attack, special_defense, speed,
                                      base_hp, base_attack, base_defense, base_special_attack, base_special_defense,
                                      base_speed, passive_ability)
                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)
                    RETURNING pet_id'''
         return await self.pool.fetchval(
-            query, owner_id, name, species, description, rarity, pet_type_to_save, skills_json,
+            query, owner_id, name, species, description, classification_tier, pet_type_to_save, skills_json,
             current_hp, max_hp, attack, defense, special_attack, special_defense, speed,
             base_hp, base_attack, base_defense, base_special_attack, base_special_defense,
             base_speed, passive_to_save

--- a/cogs/game.py
+++ b/cogs/game.py
@@ -9,12 +9,12 @@ import random
 import traceback
 
 from utils.constants import PET_DESCRIPTIONS
-from data.pets import PET_DATABASE
+from data.pets import PET_DATABASE, STARTER_SPECIES
 from utils.helpers import get_pet_image_url, get_status_bar
 from data.abilities import STARTER_TALENTS
 
 # Only starter pets shown during /start
-STARTER_PETS_LIST = [pet for pet in PET_DATABASE.values() if pet.get('rarity') == 'Starter']
+STARTER_PETS_LIST = [PET_DATABASE[species] for species in STARTER_SPECIES]
 
 
 class StartModal(discord.ui.Modal, title="Guild Registration"):
@@ -211,7 +211,7 @@ class StarterPetView(discord.ui.View):
                 name=self.selected_pet_data["species"],
                 species=self.selected_pet_data["species"],
                 description=PET_DESCRIPTIONS.get(self.selected_pet_data["species"], ""),
-                rarity=self.selected_pet_data["rarity"],
+                classification_tier=self.selected_pet_data["classification_tier"],
                 pet_type=self.selected_pet_data["pet_type"],
                 skills=starting_skills,
                 current_hp=base_stats["hp"],          max_hp=base_stats["hp"],

--- a/cogs/search.py
+++ b/cogs/search.py
@@ -59,13 +59,14 @@ CATEGORY_EMOJIS = {
     "Status": "🔄",
 }
 
-RARITY_EMOJIS = {
-    "Starter": "⭐",
-    "Common": "⚪",
-    "Uncommon": "🟢",
-    "Rare": "🔵",
-    "Epic": "🟣",
-    "Legendary": "🟡",
+CLASSIFICATION_TIER_EMOJIS = {
+    "Ordinary": "⚪",
+    "Prime": "🟢",
+    "Apex": "🔵",
+    "Elder": "🟣",
+    "Ancient": "🟠",
+    "Primordial": "🔴",
+    "Eternal": "🟡",
 }
 
 # ---------------------------------------------------------------------------
@@ -174,8 +175,8 @@ def _pet_embed(species: str) -> discord.Embed:
         type_str = f"{TYPE_EMOJIS.get(pet_type, '')} {pet_type}"
 
     color = TYPE_COLORS.get(primary_type, 0x7289DA)
-    rarity = data.get("rarity", "Common")
-    rarity_emoji = RARITY_EMOJIS.get(rarity, "⚪")
+    classification_tier = data.get("classification_tier", "Ordinary")
+    tier_emoji = CLASSIFICATION_TIER_EMOJIS.get(classification_tier, "⚪")
 
     embed = discord.Embed(
         title=f"🐾 {species}",
@@ -184,7 +185,7 @@ def _pet_embed(species: str) -> discord.Embed:
     )
 
     embed.add_field(name="Type", value=type_str, inline=True)
-    embed.add_field(name="Rarity", value=f"{rarity_emoji} {rarity}", inline=True)
+    embed.add_field(name="Classification", value=f"{tier_emoji} {classification_tier}", inline=True)
 
     personality = data.get("personality")
     if personality:

--- a/cogs/views/character.py
+++ b/cogs/views/character.py
@@ -371,10 +371,11 @@ class PetView(discord.ui.View):
         db_cog = self.bot.get_cog('Database')
         player_data = await db_cog.get_player(self.user_id)
 
-        rarity_colors = {"Starter": discord.Color.light_grey(), "Common": discord.Color.dark_grey(),
-                         "Uncommon": discord.Color.green(), "Rare": discord.Color.blue(),
-                         "Legendary": discord.Color.gold()}
-        color = rarity_colors.get(pet.rarity, discord.Color.light_grey())
+        tier_colors = {"Ordinary": discord.Color.dark_grey(), "Prime": discord.Color.green(),
+                       "Apex": discord.Color.blue(), "Elder": discord.Color.purple(),
+                       "Ancient": discord.Color.orange(), "Primordial": discord.Color.dark_red(),
+                       "Eternal": discord.Color.gold()}
+        color = tier_colors.get(pet.classification_tier, discord.Color.light_grey())
 
         is_main_pet = player_data.get('main_pet_id') == pet.pet_id
         indicator = "👑 " if is_main_pet else ""
@@ -402,7 +403,7 @@ class PetView(discord.ui.View):
         # --- Pet Details (Left Column) ---
         pet_type_str = " / ".join(pet.pet_type) if isinstance(pet.pet_type, list) else pet.pet_type
         details_text = (
-            f"**Rarity:** {pet.rarity}\n"
+            f"**Classification:** {pet.classification_tier}\n"
             f"**Type:** {pet_type_str}\n"
             f"**Personality:** {pet.personality}\n"
             f"**Talent:** {pet.passive_ability or 'None'}\n"

--- a/core/battle_engine.py
+++ b/core/battle_engine.py
@@ -9,7 +9,7 @@ from data.notifications import NOTIFICATIONS
 from data.pets import PET_DATABASE, get_pet_data
 from data.items import ITEMS
 from data.skills import PET_SKILLS
-from utils.constants import XP_REWARD_BY_RARITY
+from utils.constants import XP_REWARD_BY_TIER
 from utils.helpers import get_notification, get_type_multiplier
 from core.effect_system import (
     PASSIVE_HANDLERS_ON_HIT,
@@ -765,7 +765,7 @@ class BattleState:
                 name=self.wild_pet['species'],  # Defaults to its species name
                 species=self.wild_pet['species'],
                 description=get_pet_data(self.wild_pet['species']).get('description', ''),
-                rarity=self.wild_pet['rarity'],
+                classification_tier=self.wild_pet['classification_tier'],
                 pet_type=self.wild_pet['pet_type'],
                 skills=self.wild_pet['skills'],
                 # We use the pet's current HP from the battle
@@ -808,7 +808,10 @@ class BattleState:
             "is_gloom_touched": self.wild_pet.get('is_gloom_touched', False)
         }
 
-        RARITY_MODIFIERS = {"Common": 1.1, "Uncommon": 1.0, "Rare": 0.9, "Legendary": 0.7, "Starter": 1.0}
+        TIER_CAPTURE_MODIFIERS = {
+            "Ordinary": 1.1, "Prime": 1.0, "Apex": 0.9, "Elder": 0.75,
+            "Ancient": 0.6, "Primordial": 0.45, "Eternal": 0.3,
+        }
         PERSONALITY_MODIFIERS = {"Aggressive": 0.9, "Defensive": 0.95, "Tactical": 0.95, "Timid": 1.1}
         STATUS_MODIFIERS = {"sleep": 2.0, "paralyze": 1.5, "frozen": 2.0, "confused": 1.2}
 
@@ -833,7 +836,7 @@ class BattleState:
         current_hp = self.wild_pet.get('current_hp', 1)
         hp_factor = ((3 * max_hp) - (2 * current_hp)) / (3 * max_hp) if max_hp > 0 else 0
 
-        rarity_mult = RARITY_MODIFIERS.get(self.wild_pet.get('rarity'), 1.0)
+        tier_mult = TIER_CAPTURE_MODIFIERS.get(self.wild_pet.get('classification_tier'), 1.0)
         pers_mult = PERSONALITY_MODIFIERS.get(self.wild_pet.get('personality'), 1.0)
 
         status_mult = 1.0
@@ -862,7 +865,7 @@ class BattleState:
             orb_mult += (scaling_value * bonus_info['bonus_per_unit'])
 
         # Clamp final rate between 1 and 100
-        final_rate = max(1, min(100, int((hp_factor * base_rate) * rarity_mult * pers_mult * status_mult * orb_mult)))
+        final_rate = max(1, min(100, int((hp_factor * base_rate) * tier_mult * pers_mult * status_mult * orb_mult)))
 
         if context["is_gloom_touched"]:
             lore_text = "The Gloom's grip is weakening! The creature's spirit is fighting back."
@@ -935,7 +938,7 @@ class BattleState:
     async def _grant_rewards_for_faint(self, fainted_pet: dict):
         """Grants XP to the player's pet and handles mid-battle level up."""
         # --- ALL XP LOGIC IS NOW HERE ---
-        base_xp = XP_REWARD_BY_RARITY.get(fainted_pet['rarity'], 20)
+        base_xp = XP_REWARD_BY_TIER.get(fainted_pet['classification_tier'], 20)
         hunger_percentage = (self.player_pet.get('hunger', 0) / 100)
         is_satiated = hunger_percentage >= 0.9
 

--- a/core/pet_system.py
+++ b/core/pet_system.py
@@ -22,7 +22,7 @@ class Pet:
         self.owner_id = pet_data.get('player_id') or pet_data.get('owner_id')  # schema renamed owner_id → player_id
         self.name = pet_data.get('name', 'Unnamed')
         self.species = pet_data.get('species')
-        self.rarity = pet_data.get('rarity')
+        self.classification_tier = pet_data.get('classification_tier')
         self.pet_type = pet_data.get('pet_type')
         self.personality = pet_data.get('personality', 'Unknown')
 

--- a/core/repository.py
+++ b/core/repository.py
@@ -207,7 +207,7 @@ class SqlRepository:
     async def add_pet(self, player_id: int, species: str):
         import random, math
         pet_data = PET_DATABASE.get(species, {})
-        rarity = pet_data.get("rarity", "Common")
+        classification_tier = pet_data.get("classification_tier", "Ordinary")
         pet_type = pet_data.get("pet_type", "Normal")
         if isinstance(pet_type, list):
             pet_type = "/".join(pet_type)
@@ -241,14 +241,14 @@ class SqlRepository:
         async with self.pool.acquire() as con:
             await con.execute(
                 """INSERT INTO pets
-                   (player_id, name, species, rarity, pet_type,
+                   (player_id, name, species, classification_tier, pet_type,
                     current_hp, max_hp, attack, defense,
                     special_attack, special_defense, speed,
                     base_hp, base_attack, base_defense,
                     base_special_attack, base_special_defense, base_speed,
                     skills, passive_ability)
                    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20)""",
-                player_id, species, species, rarity, pet_type,
+                player_id, species, species, classification_tier, pet_type,
                 hp, hp, attack, defense,
                 sp_atk, sp_def, speed,
                 hp, attack, defense,

--- a/data/pets.py
+++ b/data/pets.py
@@ -8,10 +8,14 @@
 # This is now the single source of truth for ALL pet data.
 # Each pet is defined only once. Evolutions are nested inside their base form.
 
+# Top-level PET_DATABASE keys for the starter lines a new player can choose
+# from (their evolutions are not separately selectable, so they're excluded).
+STARTER_SPECIES = ["Pyrelisk", "Dewdrop", "Terran"]
+
 PET_DATABASE = {
     # --- Starter Pets ---
     "Pyrelisk": {
-        "species": "Pyrelisk", "pet_type": "Fire", "rarity": "Starter", "classification_tier": "Ordinary", "personality": "Aggressive",
+        "species": "Pyrelisk", "pet_type": "Fire", "classification_tier": "Ordinary", "personality": "Aggressive",
         "description": "A small, lizard-like creature with ember-red scales and a tail that flickers with a perpetual flame. Its eyes glow like hot coals, and it leaves tiny scorch marks wherever it steps.",
         "base_capture_rate": 35,
         "passive_ability": {
@@ -30,7 +34,7 @@ PET_DATABASE = {
         "evolutions": {
             "Blazewyrm": {
                 "evolves_at": 16,
-                "species": "Blazewyrm", "pet_type": ["Fire", "Dragon"], "rarity": "Starter", "classification_tier": "Prime",
+                "species": "Blazewyrm", "pet_type": ["Fire", "Dragon"], "classification_tier": "Prime",
                 "description": "A more imposing reptilian form, the Blazewyrm is covered in thick, heat-resistant scales and a ridge of sharp, volcanic rock that runs down its back. Its eyes burn with a low, menacing glow.",
                 "base_stat_ranges": {"hp": [60, 65], "attack": [70, 75], "defense": [45, 50], "special_attack": [65, 70],
                                      "special_defense": [45, 50], "speed": [50, 55]},
@@ -45,7 +49,7 @@ PET_DATABASE = {
                 "evolutions": {
                     "Ignisyrn": {
                         "evolves_at": 30,
-                        "species": "Ignisyrn", "pet_type": ["Fire", "Dragon"], "rarity": "Starter", "classification_tier": "Apex",
+                        "species": "Ignisyrn", "pet_type": ["Fire", "Dragon"], "classification_tier": "Apex",
                         "description": "A fearsome draconic creature with scales that glow like magma and massive wings that beat with a volcanic force. It is the undisputed predator of fiery lands.",
                         "base_stat_ranges": {"hp": [80, 85], "attack": [110, 115], "defense": [60, 65], "special_attack": [100, 105],
                                              "special_defense": [60, 65], "speed": [70, 75]},
@@ -65,7 +69,7 @@ PET_DATABASE = {
     },
 
     "Dewdrop": {
-        "species": "Dewdrop", "pet_type": "Water", "rarity": "Starter", "classification_tier": "Ordinary", "personality": "Tactical",
+        "species": "Dewdrop", "pet_type": "Water", "classification_tier": "Ordinary", "personality": "Tactical",
         "description": "A small, teardrop-shaped creature with translucent, water-blue skin that shimmers in the light. Tiny ripples flow across its body when it moves, and a soft gurgling sound follows it everywhere.",
         "base_capture_rate": 35,
         "passive_ability": {
@@ -84,7 +88,7 @@ PET_DATABASE = {
         "evolutions": {
             "Aquarius": {
                 "evolves_at": 16,
-                "species": "Aquarius", "pet_type": ["Water", "Fairy"], "rarity": "Starter", "classification_tier": "Prime",
+                "species": "Aquarius", "pet_type": ["Water", "Fairy"], "classification_tier": "Prime",
                 "description": "A bipedal, aquatic being with fins that resemble delicate feathers and a body that flows like a river. It moves with a hypnotic, liquid grace.",
                 "base_stat_ranges": {"hp": [60, 65], "attack": [45, 50], "defense": [50, 55], "special_attack": [70, 75],
                                      "special_defense": [65, 70], "speed": [55, 60]},
@@ -99,7 +103,7 @@ PET_DATABASE = {
                 "evolutions": {
                     "Aethelgale": {
                         "evolves_at": 30,
-                        "species": "Aethelgale", "pet_type": ["Water", "Fairy"], "rarity": "Starter", "classification_tier": "Apex",
+                        "species": "Aethelgale", "pet_type": ["Water", "Fairy"], "classification_tier": "Apex",
                         "description": "A guardian forged from pure, translucent water, its form constantly shifting like a flowing river. It possesses a serene, ancient wisdom in its eyes.",
                         "base_stat_ranges": {"hp": [80, 85], "attack": [60, 65], "defense": [70, 75], "special_attack": [110, 115],
                                              "special_defense": [100, 105], "speed": [75, 80]},
@@ -118,7 +122,7 @@ PET_DATABASE = {
         }
     },
     "Terran": {
-        "species": "Terran", "pet_type": "Ground", "rarity": "Starter", "classification_tier": "Ordinary", "personality": "Defensive",
+        "species": "Terran", "pet_type": "Ground", "classification_tier": "Ordinary", "personality": "Defensive",
         "description": "A squat, boulder-shaped creature covered in rough, earthy hide the color of dried clay. Despite its slow movements, it carries an unshakeable solidity, as if it were a small fragment of the earth given life.",
         "base_capture_rate": 35,
         "passive_ability": {
@@ -138,7 +142,7 @@ PET_DATABASE = {
         "evolutions": {
             "Stonehide": {
                 "evolves_at": 16,
-                "species": "Stonehide", "pet_type": ["Ground", "Rock"], "rarity": "Starter", "classification_tier": "Prime",
+                "species": "Stonehide", "pet_type": ["Ground", "Rock"], "classification_tier": "Prime",
                 "description": "A quadrupedal golem whose body is comprised of dense, layered rock. It has a single, large gem in its chest that glows with the light of the earth.",
                 "base_stat_ranges": {"hp": [65, 70], "attack": [55, 60], "defense": [75, 80], "special_attack": [40, 45],
                                      "special_defense": [50, 55], "speed": [35, 40]},
@@ -152,7 +156,7 @@ PET_DATABASE = {
                 "evolutions": {
                     "Bouldyrn": {
                         "evolves_at": 30,
-                        "species": "Bouldyrn", "pet_type": ["Ground", "Rock"], "rarity": "Starter", "classification_tier": "Apex",
+                        "species": "Bouldyrn", "pet_type": ["Ground", "Rock"], "classification_tier": "Apex",
                         "description": "A colossal golem with a fortress-like body of polished obsidian and glowing green crystals embedded within its chest. It moves slowly but with immense, unyielding power.",
                         "base_stat_ranges": {"hp": [90, 95], "attack": [75, 80], "defense": [120, 125], "special_attack": [55, 60],
                                              "special_defense": [70, 75], "speed": [45, 50]},
@@ -175,7 +179,6 @@ PET_DATABASE = {
     "Bristlecone": {
         "species": "Bristlecone",
         "pet_type": "Normal",
-        "rarity": "Common",
         "classification_tier": "Ordinary",
         "personality": "Defensive",
         "description": "A small, pine cone-shaped creature with a tough, bark-like exterior and stubby limbs. Its body is studded with short, sharp needles that bristle outward whenever it senses danger.",
@@ -199,7 +202,6 @@ PET_DATABASE = {
                 "evolves_at": 16,
                 "species": "Burlback",
                 "pet_type": ["Normal", "Grass"],
-                "rarity": "Uncommon",
                 "classification_tier": "Prime",
                 "description": "A sturdy, tree-stump-like creature whose bark has hardened into thick natural armor. Gnarled branches sprout from its back, and its slow, deliberate movements carry the weight of something ancient and unyielding.",
                 "passive_ability": {
@@ -220,7 +222,7 @@ PET_DATABASE = {
         }
     },
     "Corroder": {
-        "species": "Corroder", "pet_type": ["Rock", "Poison"], "rarity": "Common", "classification_tier": "Ordinary", "personality": "Defensive",
+        "species": "Corroder", "pet_type": ["Rock", "Poison"], "classification_tier": "Ordinary", "personality": "Defensive",
         "description": "A hunched, crab-like creature whose shell is a patchwork of calcified rock and oozing dark sludge. Its claws drip with a corrosive substance that slowly eats through anything they touch.",
         "is_gloom_touched": True,
         "gloom": {"state": "Touched", "type": "Rotting", "mark": "oozing dark sludge and a corrosive drip from the claws"},
@@ -241,7 +243,7 @@ PET_DATABASE = {
         "evolutions": {
             "Grimplate": {
                 "evolves_at": 15,
-                "species": "Grimplate", "pet_type": ["Rock", "Poison"], "rarity": "Uncommon", "classification_tier": "Prime",
+                "species": "Grimplate", "pet_type": ["Rock", "Poison"], "classification_tier": "Prime",
                 "description": "A larger, more heavily armored successor to the Corroder. Its shell has fused into dense, layered rock, and the toxic sludge it secretes has thickened into a viscous, slow-dripping poison.",
                 "base_stat_ranges": {"hp": [60, 65], "attack": [45, 50], "defense": [70, 75],
                                      "special_attack": [35, 40],
@@ -257,7 +259,7 @@ PET_DATABASE = {
                 "evolutions": {
                     "Blightcrust": {
                         "evolves_at": 30,
-                        "species": "Blightcrust", "pet_type": ["Rock", "Poison"], "rarity": "Rare", "classification_tier": "Apex",
+                        "species": "Blightcrust", "pet_type": ["Rock", "Poison"], "classification_tier": "Apex",
                         "is_gloom_touched": True,
                         "gloom": {"state": "Shorn", "type": "Rotting", "mark": "fused bones and hardened sludge radiating an aura of decay"},
                         "description": "A towering construct of fused bones and hardened sludge, shaped by years of Gloom exposure into something ancient and terrifying. It moves slowly but radiates an aura of decay that withers anything that lingers too close.",
@@ -283,7 +285,6 @@ PET_DATABASE = {
     "Mossling": {
         "species": "Mossling",
         "pet_type": "Grass",
-        "rarity": "Common",
         "classification_tier": "Ordinary",
         "personality": "Timid",
         "description": "A small, moss-covered creature that blends seamlessly into the forest floor. Its timid nature means it will flee at the first sign of danger, but it becomes surprisingly resilient when cornered.",
@@ -307,7 +308,6 @@ PET_DATABASE = {
                 "evolves_at": 14,
                 "species": "Thornmoss",
                 "pet_type": ["Grass", "Rock"],
-                "rarity": "Uncommon",
                 "classification_tier": "Prime",
                 "description": "As Mossling matures, its soft coat hardens into a dense layer of moss-covered rock. Sharp thorns protrude from its back, and it carries itself with a quiet, unmovable confidence.",
                 "passive_ability": {
@@ -329,7 +329,6 @@ PET_DATABASE = {
                         "evolves_at": 28,
                         "species": "Ferngale",
                         "pet_type": ["Grass", "Rock"],
-                        "rarity": "Rare",
                         "classification_tier": "Apex",
                         "description": "An ancient, towering form wrapped in layers of living stone and cascading fern. Ferngale moves slowly but commands the battlefield with a primal authority — the forest itself seems to bend around it.",
                         "passive_ability": {
@@ -356,7 +355,6 @@ PET_DATABASE = {
     "Glimmerva": {
         "species": "Glimmerva",
         "pet_type": "Bug",
-        "rarity": "Common",
         "classification_tier": "Ordinary",
         "personality": "Timid",
         "description": "A soft-bodied, wingless larva covered in fine, glowing scales. It clings to sun-warmed leaves and bark, pulsing faintly with light when disturbed. Slow and harmless-looking, but the dust it sheds when threatened can be surprisingly disorienting.",
@@ -380,7 +378,6 @@ PET_DATABASE = {
                 "evolves_at": 15,
                 "species": "Luminara",
                 "pet_type": ["Bug"],
-                "rarity": "Uncommon",
                 "classification_tier": "Prime",
                 "description": "Freshly emerged from its cocoon, Luminara's wings are still soft and unfolding, glimmering faintly even in shade. It moves in short, fluttering bursts, not yet trusting its new wings, but already drawn toward warmth and light.",
                 "passive_ability": {
@@ -402,7 +399,6 @@ PET_DATABASE = {
                         "evolves_at": 30,
                         "species": "Solarmoth",
                         "pet_type": ["Bug", "Fire"],
-                        "rarity": "Rare",
                         "classification_tier": "Apex",
                         "description": "Its metamorphosis complete, Solarmoth's wings have unfurled into great radiant fans that seem to burn with trapped sunlight. It glides rather than flutters now, leaving faint trails of warmth in the air, and even at night its wings continue to glow like embers.",
                         "passive_ability": {
@@ -427,7 +423,6 @@ PET_DATABASE = {
     "Grimweave": {
         "species": "Grimweave",
         "pet_type": ["Ghost", "Poison"],
-        "rarity": "Uncommon",
         "classification_tier": "Prime",
         "personality": "Aggressive",
         "description": "A shadowy, arachnid-like creature that weaves webs of Gloom-infused silk between the trees at night. Its presence makes the air feel cold and heavy, and the faint glow of its eyes is often the only warning before it strikes.",
@@ -453,7 +448,6 @@ PET_DATABASE = {
                 "evolves_at": 16,
                 "species": "Duskspinner",
                 "pet_type": ["Ghost", "Poison"],
-                "rarity": "Rare",
                 "classification_tier": "Apex",
                 "description": "A larger, more terrifying form that wraps itself in a shroud of writhing Gloom-silk. Its eight limbs move with unsettling precision, and the webs it spins can trap both body and spirit.",
                 "passive_ability": {
@@ -475,7 +469,6 @@ PET_DATABASE = {
                         "evolves_at": 30,
                         "species": "Veilmother",
                         "pet_type": ["Ghost", "Poison"],
-                        "rarity": "Ancient",
                         "classification_tier": "Elder",
                         "is_gloom_touched": True,
                         "gloom": {"state": "Hollow", "type": "Shrouded", "mark": "a vast, passive web-shroud — what's left of the self has emptied into something that only waits"},
@@ -509,7 +502,6 @@ PET_DATABASE = {
     "Moonwisp": {
         "species": "Moonwisp",
         "pet_type": ["Fairy", "Grass"],
-        "rarity": "Uncommon",
         "classification_tier": "Prime",
         "personality": "Tactical",
         "description": "A tiny, luminescent creature that dances among moonlit flowers in the depths of Whisperwood. Gentle by nature, it uses its fae magic to confound and disorient those who threaten its home rather than fighting directly.",
@@ -533,7 +525,6 @@ PET_DATABASE = {
                 "evolves_at": 15,
                 "species": "Lunarblossom",
                 "pet_type": ["Fairy", "Grass"],
-                "rarity": "Rare",
                 "classification_tier": "Apex",
                 "description": "A graceful, flower-crowned being that radiates a soft silver light. It moves as if weightless, leaving a faint trail of glowing petals wherever it steps. Its fae magic has deepened into something ancient and difficult to resist.",
                 "passive_ability": {
@@ -557,7 +548,6 @@ PET_DATABASE = {
     "Serpentine": {
         "species": "Serpentine",
         "pet_type": ["Grass", "Dark"],
-        "rarity": "Uncommon",
         "classification_tier": "Prime",
         "personality": "Tactical",
         "description": "A slender, vine-like serpent that moves silently through the underbrush, its scales shifting between deep green and shadow depending on the light. It prefers to watch from cover for long stretches before ever striking.",
@@ -581,7 +571,6 @@ PET_DATABASE = {
                 "evolves_at": 20,
                 "species": "Serpumbra",
                 "pet_type": ["Grass", "Dark"],
-                "rarity": "Rare",
                 "classification_tier": "Apex",
                 "description": "Serpentine's final form — a long, shadow-wreathed serpent whose scales seem to drink in the light around it. In dappled forest shade it can vanish almost entirely, becoming little more than a rustle in the leaves and a pair of watching eyes.",
                 "passive_ability": {
@@ -605,7 +594,6 @@ PET_DATABASE = {
     "Glamorose": {
         "species": "Glamorose",
         "pet_type": ["Grass", "Poison"],
-        "rarity": "Common",
         "classification_tier": "Ordinary",
         "personality": "Tactical",
         "description": "A small, flower-headed creature with petals of an almost unnaturally vivid pink. Its sweet fragrance draws other creatures close — a little too close, and a little too often for it to be entirely accidental.",
@@ -629,7 +617,6 @@ PET_DATABASE = {
                 "evolves_at": 18,
                 "species": "Malicea",
                 "pet_type": ["Grass", "Poison"],
-                "rarity": "Uncommon",
                 "classification_tier": "Prime",
                 "description": "Malicea's petals have unfurled wider and its fragrance grown richer — sweeter, even, the closer one gets to the soft rot at its core. Things that wander too near tend to linger longer than they mean to.",
                 "passive_ability": {
@@ -651,7 +638,6 @@ PET_DATABASE = {
                         "evolves_at": 38,
                         "species": "Aberraflora",
                         "pet_type": ["Grass", "Poison"],
-                        "rarity": "Ancient",
                         "classification_tier": "Elder",
                         "description": (
                             "The final form of the Glamorose line. A sprawling mass of bloom and "
@@ -683,7 +669,6 @@ PET_DATABASE = {
     "Verdanthorn": {
         "species": "Verdanthorn",
         "pet_type": ["Grass", "Normal"],
-        "rarity": "Ancient",
         "classification_tier": "Elder",
         "personality": "Defensive",
         "description": (
@@ -717,7 +702,6 @@ PET_DATABASE = {
     "Cinderkit": {
         "species": "Cinderkit",
         "pet_type": "Fire",
-        "rarity": "Common",
         "classification_tier": "Ordinary",
         "personality": "Timid",
         "description": (
@@ -745,7 +729,6 @@ PET_DATABASE = {
                 "evolves_at": 16,
                 "species": "Ashveil",
                 "pet_type": "Fire",
-                "rarity": "Uncommon",
                 "classification_tier": "Prime",
                 "description": (
                     "Bigger and leaner than Cinderkit. The ember streaks have become "
@@ -773,7 +756,6 @@ PET_DATABASE = {
     "Tindertail": {
         "species": "Tindertail",
         "pet_type": "Fire",
-        "rarity": "Uncommon",
         "classification_tier": "Prime",
         "personality": "Tactical",
         "description": (
@@ -802,7 +784,6 @@ PET_DATABASE = {
     "Smolderoot": {
         "species": "Smolderoot",
         "pet_type": ["Grass", "Fire"],
-        "rarity": "Uncommon",
         "classification_tier": "Prime",
         "personality": "Defensive",
         "description": (
@@ -830,7 +811,6 @@ PET_DATABASE = {
                 "evolves_at": 30,
                 "species": "Pyrethorn",
                 "pet_type": ["Grass", "Fire"],
-                "rarity": "Rare",
                 "classification_tier": "Apex",
                 "description": (
                     "Smolderoot's larger form — gnarled, root-legged, hunched, walking "
@@ -858,7 +838,6 @@ PET_DATABASE = {
     "Cindermaw": {
         "species": "Cindermaw",
         "pet_type": ["Grass", "Fire"],
-        "rarity": "Ancient",
         "classification_tier": "Elder",
         "personality": "Defensive",
         "description": (
@@ -888,7 +867,6 @@ PET_DATABASE = {
     "Pyrehart": {
         "species": "Pyrehart",
         "pet_type": "Fire",
-        "rarity": "Ancient",
         "classification_tier": "Elder",
         "personality": "Aggressive",
         "description": (
@@ -921,7 +899,7 @@ PET_DATABASE = {
     # -------------------------------------------------------------------------
 
     "Stillroot": {
-        "species": "Stillroot", "pet_type": ["Rock", "Grass"], "rarity": "Common", "classification_tier": "Apex",  # bumped from Ordinary so its unique Stonecrust passive isn't overridden by the shared pool — fits its Gloom-marked, Rare-sighting status at the Weeping Root
+        "species": "Stillroot", "pet_type": ["Rock", "Grass"], "classification_tier": "Apex",  # bumped from Ordinary so its unique Stonecrust passive isn't overridden by the shared pool — fits its Gloom-marked, Rare-sighting status at the Weeping Root
         "personality": "Steadfast",
         "is_gloom_touched": True,
         "gloom": {"state": "Touched", "type": "Calcifying", "mark": "patches of genuine stone-like growth across the body, stalled in place"},
@@ -954,7 +932,7 @@ PET_DATABASE = {
     },
 
     "Veinglow": {
-        "species": "Veinglow", "pet_type": ["Poison", "Grass"], "rarity": "Uncommon", "classification_tier": "Prime",
+        "species": "Veinglow", "pet_type": ["Poison", "Grass"], "classification_tier": "Prime",
         "personality": "Cautious",
         "is_gloom_touched": False,
         "description": (
@@ -992,7 +970,7 @@ PET_DATABASE = {
     # -------------------------------------------------------------------------
 
     "Gauntling": {
-        "species": "Gauntling", "pet_type": ["Ghost", "Normal"], "rarity": "Common", "classification_tier": "Ordinary",
+        "species": "Gauntling", "pet_type": ["Ghost", "Normal"], "classification_tier": "Ordinary",
         "personality": "Timid",
         "is_gloom_touched": True,
         "gloom": {"state": "Touched", "type": "Fading", "mark": "partially translucent body, slowly losing physical definition"},
@@ -1023,7 +1001,7 @@ PET_DATABASE = {
         "evolutions": {
             "Waneling": {
                 "evolves_at": 15,
-                "species": "Waneling", "pet_type": ["Ghost", "Normal"], "rarity": "Uncommon", "classification_tier": "Prime",
+                "species": "Waneling", "pet_type": ["Ghost", "Normal"], "classification_tier": "Prime",
                 "is_gloom_touched": True,
                 "gloom": {"state": "Shorn", "type": "Fading", "mark": "more ghost than creature, barely visible — sensed more than seen"},
                 "description": (
@@ -1049,7 +1027,7 @@ PET_DATABASE = {
     },
 
     "Rimecrawl": {
-        "species": "Rimecrawl", "pet_type": ["Ice", "Poison"], "rarity": "Uncommon", "classification_tier": "Prime",
+        "species": "Rimecrawl", "pet_type": ["Ice", "Poison"], "classification_tier": "Prime",
         "personality": "Defensive",
         "is_gloom_touched": True,
         "gloom": {"state": "Touched", "type": "Frostbound", "mark": "trails of frost-laced Gloom residue, cold to the touch"},
@@ -1080,7 +1058,7 @@ PET_DATABASE = {
         "evolutions": {
             "Frostbile": {
                 "evolves_at": 16,
-                "species": "Frostbile", "pet_type": ["Ice", "Poison"], "rarity": "Rare", "classification_tier": "Apex",
+                "species": "Frostbile", "pet_type": ["Ice", "Poison"], "classification_tier": "Apex",
                 "is_gloom_touched": True,
                 "gloom": {"state": "Shorn", "type": "Frostbound", "mark": "crystallized frost trails that turn the terrain itself into a weapon"},
                 "description": (
@@ -1106,7 +1084,7 @@ PET_DATABASE = {
     },
 
     "Threshling": {
-        "species": "Threshling", "pet_type": ["Dark", "Ghost"], "rarity": "Rare", "classification_tier": "Apex",
+        "species": "Threshling", "pet_type": ["Dark", "Ghost"], "classification_tier": "Apex",
         "personality": "Aggressive",
         "is_gloom_touched": True,
         "gloom": {"state": "Shorn", "type": "Thresholdbound", "mark": "half-solid, half-mist body; one eye clear, one eye dark"},
@@ -1137,7 +1115,7 @@ PET_DATABASE = {
         "evolutions": {
             "Threshbound": {
                 "evolves_at": 20,
-                "species": "Threshbound", "pet_type": ["Dark", "Ghost"], "rarity": "Ancient", "classification_tier": "Elder",
+                "species": "Threshbound", "pet_type": ["Dark", "Ghost"], "classification_tier": "Elder",
                 "is_gloom_touched": True,
                 "gloom": {"state": "Hollow", "type": "Thresholdbound", "mark": "no longer at the threshold — it IS the threshold, defying classification"},
                 "description": (
@@ -1174,7 +1152,7 @@ PET_DATABASE = {
     # -------------------------------------------------------------------------
 
     "Murkback": {
-        "species": "Murkback", "pet_type": ["Water", "Ground"], "rarity": "Common", "classification_tier": "Ordinary",
+        "species": "Murkback", "pet_type": ["Water", "Ground"], "classification_tier": "Ordinary",
         "personality": "Defensive",
         "description": (
             "A squat, wide-bodied amphibian armored with a crust of dried mud and silt. "
@@ -1202,7 +1180,7 @@ PET_DATABASE = {
         "evolutions": {
             "Murkwall": {
                 "evolves_at": 15,
-                "species": "Murkwall", "pet_type": ["Water", "Ground"], "rarity": "Uncommon", "classification_tier": "Prime",
+                "species": "Murkwall", "pet_type": ["Water", "Ground"], "classification_tier": "Prime",
                 "description": (
                     "Larger, slower, and nearly immovable. The hide has thickened into "
                     "layered mud-rock plating. Murkback's territorial instinct has become "
@@ -1228,7 +1206,7 @@ PET_DATABASE = {
     },
 
     "Pallefin": {
-        "species": "Pallefin", "pet_type": "Water", "rarity": "Uncommon", "classification_tier": "Prime",
+        "species": "Pallefin", "pet_type": "Water", "classification_tier": "Prime",
         "personality": "Timid",
         "description": (
             "A small, almost translucent creature that skims the water surface without "
@@ -1257,7 +1235,7 @@ PET_DATABASE = {
         "evolutions": {
             "Shimmerdeep": {
                 "evolves_at": 16,
-                "species": "Shimmerdeep", "pet_type": "Water", "rarity": "Rare", "classification_tier": "Apex",
+                "species": "Shimmerdeep", "pet_type": "Water", "classification_tier": "Apex",
                 "description": (
                     "No longer skims the surface — descends. The translucency becomes "
                     "a faint bioluminescence, generating soft light in dark water. "
@@ -1283,7 +1261,7 @@ PET_DATABASE = {
     },
 
     "Siltborn": {
-        "species": "Siltborn", "pet_type": ["Poison", "Grass"], "rarity": "Rare", "classification_tier": "Apex",
+        "species": "Siltborn", "pet_type": ["Poison", "Grass"], "classification_tier": "Apex",
         "personality": "Aggressive",
         "is_gloom_touched": False,
         "description": (
@@ -1313,7 +1291,7 @@ PET_DATABASE = {
         "evolutions": {
             "Mirewarden": {
                 "evolves_at": 18,
-                "species": "Mirewarden", "pet_type": ["Poison", "Grass"], "rarity": "Very Rare", "classification_tier": "Elder",
+                "species": "Mirewarden", "pet_type": ["Poison", "Grass"], "classification_tier": "Elder",
                 "is_gloom_touched": False,
                 "description": (
                     "Larger, denser. Reeds and roots have grown through it, not just "

--- a/migrations/013_pet_classification_tier.py
+++ b/migrations/013_pet_classification_tier.py
@@ -1,0 +1,32 @@
+# migrations/013_pet_classification_tier.py
+
+async def apply(cursor):
+    """
+    Migration 013: Replaces the legacy per-pet `rarity` column with
+    `classification_tier`.
+
+    The old `rarity` values (Starter/Common/Uncommon/Rare/Ancient/"Very Rare")
+    are being retired in favor of the Classification Tier system
+    (Ordinary/Prime/Apex/Elder/Ancient/Primordial/Eternal) — see
+    docs/design/world/pets_rarity_cleanup.md.
+
+    This renames the column and backfills every existing row from
+    PET_DATABASE's classification_tier for that species, falling back to
+    'Ordinary' for any species no longer present in the database.
+    """
+    await cursor.execute("""
+        ALTER TABLE pets RENAME COLUMN rarity TO classification_tier
+    """)
+
+    # Backfill from PET_DATABASE so existing pets get their proper tier
+    # instead of the stale rarity string that used to live in this column.
+    from data.pets import PET_DATABASE
+
+    rows = await cursor.fetch("SELECT DISTINCT species FROM pets")
+    for row in rows:
+        species = row["species"]
+        tier = PET_DATABASE.get(species, {}).get("classification_tier", "Ordinary")
+        await cursor.execute(
+            "UPDATE pets SET classification_tier = $1 WHERE species = $2",
+            tier, species,
+        )

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -88,19 +88,16 @@ PET_DESCRIPTIONS = {
     "Corroder": "A foul creature born from the tainted sludge of the Rotting Pits, its rocky hide drips with a weak poison.",
 }
 
-# Define pet evolutions (to be used later)
-PET_EVOLUTIONS = {
-    "Mossling": {
-        "level": 20,
-        "species": "Verdant Golem"
-    }
-}
-
-XP_REWARD_BY_RARITY = {
-    "Common": 20,
-    "Uncommon": 30,
-    "Rare": 45,
-    "Legendary": 100,
+# XP granted to the player's pet for defeating a wild pet, keyed by the
+# defeated pet's classification_tier (see data/classifications.py).
+XP_REWARD_BY_TIER = {
+    "Ordinary": 20,
+    "Prime": 30,
+    "Apex": 45,
+    "Elder": 70,
+    "Ancient": 100,
+    "Primordial": 150,
+    "Eternal": 200,
 }
 
 ## --- REFACTORING CHANGES ---

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -148,7 +148,7 @@ def _pet_tuple_to_dict(pet_data: tuple) -> Dict[str, Any]:
     if isinstance(pet_data, dict): return pet_data
 
     # This is the corrected list of keys in the exact order of your new database table
-    keys = ['pet_id', 'player_id', 'name', 'species', 'description', 'rarity', 'pet_type', 'level', 'xp', 'current_hp', 'max_hp', 'attack', 'defense', 'special_attack', 'special_defense', 'speed', 'base_hp', 'base_attack', 'base_defense', 'base_special_attack', 'base_special_defense', 'base_speed', 'hunger', 'skills', 'is_in_party', 'passive_ability']
+    keys = ['pet_id', 'player_id', 'name', 'species', 'description', 'classification_tier', 'pet_type', 'level', 'xp', 'current_hp', 'max_hp', 'attack', 'defense', 'special_attack', 'special_defense', 'speed', 'base_hp', 'base_attack', 'base_defense', 'base_special_attack', 'base_special_defense', 'base_speed', 'hunger', 'skills', 'is_in_party', 'passive_ability']
 
     # Ensure the data from the database has the same number of items as our keys
     if len(keys) != len(pet_data):


### PR DESCRIPTION
## Summary
- Renames the legacy per-pet `rarity` column/field to `classification_tier` across DB schema, repository/database layers, battle engine, UI, and pet data (migration 013).
- Adds `STARTER_SPECIES` (data/pets.py) to replace the old `rarity == 'Starter'` filter.
- Adds `XP_REWARD_BY_TIER` (7-tier) and `TIER_CAPTURE_MODIFIERS` (7-tier) replacing the old rarity-keyed tables.
- Fixes a display gap where Elder/Ancient tier pets had no color mapping in the character panel.

## Test plan
- [x] `ast.parse` on all 13 modified files
- [x] Verified zero remaining `"rarity"` keys in `data/pets.py`
- [x] Verified Stillroot remains `classification_tier: Apex` (intentional, pre-passive-system)
- [x] Verified Mirewarden nested evolution tier = Elder
- [ ] Manual smoke test of `/encounter`, capture, and character panel after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)